### PR TITLE
feat: add Sprite character companion

### DIFF
--- a/docs/superpowers/plans/2026-04-28-sprite.md
+++ b/docs/superpowers/plans/2026-04-28-sprite.md
@@ -1,0 +1,1424 @@
+# Sprite Feature Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an optional character companion ("Sprite") to the right sidebar that reacts to AI terminal output via speech bubbles, with a persona injected at session creation.
+
+**Architecture:** A pure `parseSpriteSpeech` function in the main process intercepts PTY data side-channel and emits `sprite:speech` IPC events to the renderer without touching the xterm stream. A Zustand store persisted to localStorage holds Sprite definitions. `RightSidebar` owns both the existing `GitPanel` and the new `SpritePanel`; `SpriteStudio` is a modal for creating/editing Sprites.
+
+**Tech Stack:** `@dicebear/core`, `@dicebear/collection` (renderer-only SVG generation), Zustand + persist middleware (localStorage), Electron contextBridge IPC, Jest + React Testing Library.
+
+---
+
+## File Map
+
+**Create:**
+- `src/main/sprite-parser.ts` — pure `parseSpriteSpeech(chunk): ParsedSpriteEvent[]`
+- `src/renderer/store/sprites.ts` — Zustand store (Sprite CRUD, localStorage persist)
+- `src/renderer/components/RightSidebar.tsx` — wraps GitPanel + SpritePanel
+- `src/renderer/components/SpritePanel.tsx` — avatar, speech bubble, empty state
+- `src/renderer/components/SpriteStudio.tsx` — create/edit modal
+- `tests/main/sprite-parser.test.ts`
+- `tests/renderer/sprites-store.test.tsx`
+- `tests/renderer/SpritePanel.test.tsx`
+- `tests/renderer/SpriteStudio.test.tsx`
+
+**Modify:**
+- `src/renderer/types/ipc.ts` — `Session.spriteId`, `CreateSessionOptions.spriteId/persona`, `IPC.SPRITE_SPEECH`, new `KeybindingAction` values + defaults
+- `src/renderer/types/electron.d.ts` — add `onSpriteSpeech` to `window.overseer`
+- `src/main/preload.ts` — expose `onSpriteSpeech`
+- `src/main/ipc-handlers.ts` — call `parseSpriteSpeech` in `service.onData`, emit `sprite:speech`
+- `src/main/session-service/index.ts` — store persona in envVars, write claude startup command
+- `src/renderer/components/GitPanel.tsx` — remove self-owned width/border (now owned by RightSidebar)
+- `src/renderer/components/NewSessionDialog.tsx` — sprite selector dropdown
+- `src/renderer/hooks/useKeyboardShortcuts.ts` — add `onToggleSpritePanel`, `onOpenSpriteStudio` handlers
+- `src/renderer/components/KeyboardShortcutsModal.tsx` — add sprite actions to GROUPS + ACTION_LABELS
+- `src/renderer/App.tsx` — swap GitPanel → RightSidebar, add sprite keybinding handlers + SpriteStudio modal state
+
+---
+
+## Task 1: Install DiceBear
+
+**Files:**
+- Modify: `package.json` (via npm install)
+
+- [ ] **Step 1: Install packages**
+
+```bash
+cd /home/toryhebert/src/overseer
+npm install @dicebear/core @dicebear/collection
+```
+
+Expected: Both packages appear in `node_modules/@dicebear/` and `package.json` dependencies.
+
+- [ ] **Step 2: Verify types are available**
+
+```bash
+ls node_modules/@dicebear/core/dist/index.d.ts
+ls node_modules/@dicebear/collection/dist/index.d.ts
+```
+
+Expected: Both files exist.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore: add @dicebear/core and @dicebear/collection"
+```
+
+---
+
+## Task 2: sprite-parser — pure parser + tests
+
+**Files:**
+- Create: `src/main/sprite-parser.ts`
+- Create: `tests/main/sprite-parser.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/main/sprite-parser.test.ts`:
+
+```ts
+import { parseSpriteSpeech } from '../../src/main/sprite-parser'
+
+test('returns empty array for chunk with no speak tags', () => {
+  expect(parseSpriteSpeech('hello world')).toEqual([])
+})
+
+test('returns empty array for empty string', () => {
+  expect(parseSpriteSpeech('')).toEqual([])
+})
+
+test('extracts a single speak tag', () => {
+  expect(parseSpriteSpeech('<speak>hey there</speak>')).toEqual([
+    { type: 'speech', text: 'hey there' },
+  ])
+})
+
+test('extracts multiple speak tags from one chunk', () => {
+  expect(parseSpriteSpeech('foo <speak>one</speak> bar <speak>two</speak> baz')).toEqual([
+    { type: 'speech', text: 'one' },
+    { type: 'speech', text: 'two' },
+  ])
+})
+
+test('ignores unclosed speak tags', () => {
+  expect(parseSpriteSpeech('<speak>unclosed')).toEqual([])
+})
+
+test('ignores empty speak tags', () => {
+  expect(parseSpriteSpeech('<speak></speak>')).toEqual([])
+})
+
+test('handles speak tag mixed with other output', () => {
+  const chunk = '[32msome ansi[0m <speak>hello sailor</speak> more text'
+  expect(parseSpriteSpeech(chunk)).toEqual([{ type: 'speech', text: 'hello sailor' }])
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npx jest tests/main/sprite-parser.test.ts --no-coverage
+```
+
+Expected: All tests fail with "Cannot find module '../../src/main/sprite-parser'".
+
+- [ ] **Step 3: Implement the parser**
+
+Create `src/main/sprite-parser.ts`:
+
+```ts
+export interface ParsedSpriteEvent {
+  type: 'speech'
+  text: string
+}
+
+const SPEAK_REGEX = /<speak>([\s\S]+?)<\/speak>/g
+
+export function parseSpriteSpeech(chunk: string): ParsedSpriteEvent[] {
+  const events: ParsedSpriteEvent[] = []
+  let match: RegExpExecArray | null
+  SPEAK_REGEX.lastIndex = 0
+  while ((match = SPEAK_REGEX.exec(chunk)) !== null) {
+    const text = match[1].trim()
+    if (text) events.push({ type: 'speech', text })
+  }
+  return events
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npx jest tests/main/sprite-parser.test.ts --no-coverage
+```
+
+Expected: All 7 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/sprite-parser.ts tests/main/sprite-parser.test.ts
+git commit -m "feat(sprite): add parseSpriteSpeech pure parser"
+```
+
+---
+
+## Task 3: Types — Session, CreateSessionOptions, IPC constant, keybindings
+
+**Files:**
+- Modify: `src/renderer/types/ipc.ts`
+
+- [ ] **Step 1: Add `spriteId` to `Session` interface**
+
+In `src/renderer/types/ipc.ts`, update the `Session` interface:
+
+```ts
+export interface Session {
+  id: string
+  name: string
+  agentType: 'claude' | 'gemini' | 'cursor' | 'shell'
+  cwd: string
+  envVars: Record<string, string>
+  scrollbackPath: string
+  spriteId: string | null
+}
+```
+
+- [ ] **Step 2: Add `spriteId` and `persona` to `CreateSessionOptions`**
+
+```ts
+export interface CreateSessionOptions {
+  name: string
+  agentType: Session['agentType']
+  cwd?: string
+  spriteId?: string | null
+  persona?: string
+}
+```
+
+- [ ] **Step 3: Add `SPRITE_SPEECH` to the `IPC` const**
+
+In the `IPC` object at the bottom of `src/renderer/types/ipc.ts`, add:
+
+```ts
+export const IPC = {
+  // ... existing entries ...
+  SPRITE_SPEECH: 'sprite:speech',
+} as const
+```
+
+- [ ] **Step 4: Add keybinding actions**
+
+In `KeybindingAction` type, add:
+
+```ts
+export type KeybindingAction =
+  | 'newSession'
+  | 'killSession'
+  | 'nextSession'
+  | 'prevSession'
+  | 'sessionByIndex1'
+  | 'sessionByIndex2'
+  | 'sessionByIndex3'
+  | 'sessionByIndex4'
+  | 'sessionByIndex5'
+  | 'sessionByIndex6'
+  | 'sessionByIndex7'
+  | 'sessionByIndex8'
+  | 'sessionByIndex9'
+  | 'openDrawer'
+  | 'openSettings'
+  | 'openShortcuts'
+  | 'splitFocus'
+  | 'splitFocusPrev'
+  | 'splitOpenThreeWay'
+  | 'splitClose'
+  | 'splitSwap'
+  | 'splitSwapSecondary'
+  | 'splitToggleDirection'
+  | 'toggleSpritePanel'
+  | 'openSpriteStudio'
+```
+
+- [ ] **Step 5: Add defaults for the new keybindings**
+
+In `DEFAULT_KEYBINDINGS`, add at the end:
+
+```ts
+  toggleSpritePanel: { code: 'KeyS', ctrl: true, shift: true, alt: false },
+  openSpriteStudio:  { code: 'KeyP', ctrl: true, shift: true, alt: false },
+```
+
+- [ ] **Step 6: Verify TypeScript compiles**
+
+```bash
+npx tsc -p tsconfig.main.json --noEmit
+```
+
+Expected: No errors.
+
+- [ ] **Step 7: Run existing tests to check no regressions**
+
+```bash
+npx jest --no-coverage 2>&1 | tail -20
+```
+
+Expected: All existing tests pass (some may need the `spriteId` field on Session mocks — fix any failures by adding `spriteId: null` to mock Session objects in test files that construct Session objects directly).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/renderer/types/ipc.ts
+git commit -m "feat(sprite): add spriteId to Session, SPRITE_SPEECH IPC constant, and sprite keybinding actions"
+```
+
+---
+
+## Task 4: Sprite Zustand store + tests
+
+**Files:**
+- Create: `src/renderer/store/sprites.ts`
+- Create: `tests/renderer/sprites-store.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/renderer/sprites-store.test.tsx`:
+
+```tsx
+import { useSpritesStore } from '../../src/renderer/store/sprites'
+
+beforeEach(() => {
+  localStorage.clear()
+  useSpritesStore.setState({ sprites: [] })
+})
+
+test('createSprite adds a sprite with a generated id', () => {
+  const { createSprite } = useSpritesStore.getState()
+  const sprite = createSprite({ name: 'Salty', style: 'bottts', seed: 'sailor', persona: 'old sailor' })
+  expect(sprite.id).toBeTruthy()
+  expect(typeof sprite.id).toBe('string')
+  expect(useSpritesStore.getState().sprites).toHaveLength(1)
+  expect(useSpritesStore.getState().sprites[0].name).toBe('Salty')
+})
+
+test('createSprite gives each sprite a unique id', () => {
+  const { createSprite } = useSpritesStore.getState()
+  const a = createSprite({ name: 'A', style: 'bottts', seed: 'a', persona: '' })
+  const b = createSprite({ name: 'B', style: 'bottts', seed: 'b', persona: '' })
+  expect(a.id).not.toBe(b.id)
+})
+
+test('updateSprite patches only the named fields', () => {
+  const { createSprite, updateSprite } = useSpritesStore.getState()
+  const sprite = createSprite({ name: 'Salty', style: 'bottts', seed: 'sailor', persona: 'grumpy sailor' })
+  updateSprite(sprite.id, { name: 'Salty McSaltface' })
+  const updated = useSpritesStore.getState().sprites[0]
+  expect(updated.name).toBe('Salty McSaltface')
+  expect(updated.persona).toBe('grumpy sailor')
+})
+
+test('updateSprite ignores unknown ids', () => {
+  const { createSprite, updateSprite } = useSpritesStore.getState()
+  createSprite({ name: 'Salty', style: 'bottts', seed: 'sailor', persona: 'grumpy' })
+  updateSprite('does-not-exist', { name: 'X' })
+  expect(useSpritesStore.getState().sprites[0].name).toBe('Salty')
+})
+
+test('deleteSprite removes the sprite by id', () => {
+  const { createSprite, deleteSprite } = useSpritesStore.getState()
+  const sprite = createSprite({ name: 'Salty', style: 'bottts', seed: 'sailor', persona: '' })
+  deleteSprite(sprite.id)
+  expect(useSpritesStore.getState().sprites).toHaveLength(0)
+})
+
+test('deleteSprite leaves other sprites untouched', () => {
+  const { createSprite, deleteSprite } = useSpritesStore.getState()
+  const a = createSprite({ name: 'A', style: 'bottts', seed: 'a', persona: '' })
+  const b = createSprite({ name: 'B', style: 'bottts', seed: 'b', persona: '' })
+  deleteSprite(a.id)
+  expect(useSpritesStore.getState().sprites).toHaveLength(1)
+  expect(useSpritesStore.getState().sprites[0].id).toBe(b.id)
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npx jest tests/renderer/sprites-store.test.tsx --no-coverage
+```
+
+Expected: All tests fail with "Cannot find module '../../src/renderer/store/sprites'".
+
+- [ ] **Step 3: Implement the store**
+
+Create `src/renderer/store/sprites.ts`:
+
+```ts
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+import { v4 as uuidv4 } from 'uuid'
+
+export interface Sprite {
+  id: string
+  name: string
+  style: string  // DiceBear collection key — MVP: always 'bottts'
+  seed: string
+  persona: string
+}
+
+interface SpritesState {
+  sprites: Sprite[]
+  createSprite: (s: Omit<Sprite, 'id'>) => Sprite
+  updateSprite: (id: string, patch: Partial<Omit<Sprite, 'id'>>) => void
+  deleteSprite: (id: string) => void
+}
+
+export const useSpritesStore = create<SpritesState>()(
+  persist(
+    (set) => ({
+      sprites: [],
+      createSprite: (s) => {
+        const sprite: Sprite = { ...s, id: uuidv4() }
+        set(state => ({ sprites: [...state.sprites, sprite] }))
+        return sprite
+      },
+      updateSprite: (id, patch) => {
+        set(state => ({
+          sprites: state.sprites.map(s => s.id === id ? { ...s, ...patch } : s),
+        }))
+      },
+      deleteSprite: (id) => {
+        set(state => ({ sprites: state.sprites.filter(s => s.id !== id) }))
+      },
+    }),
+    { name: 'overseer-sprites' }
+  )
+)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npx jest tests/renderer/sprites-store.test.tsx --no-coverage
+```
+
+Expected: All 6 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/store/sprites.ts tests/renderer/sprites-store.test.tsx
+git commit -m "feat(sprite): add Sprite Zustand store with localStorage persistence"
+```
+
+---
+
+## Task 5: Side-channel IPC wiring
+
+**Files:**
+- Modify: `src/main/ipc-handlers.ts`
+- Modify: `src/main/preload.ts`
+- Modify: `src/renderer/types/electron.d.ts`
+
+- [ ] **Step 1: Import `parseSpriteSpeech` and emit `sprite:speech` in `ipc-handlers.ts`**
+
+In `src/main/ipc-handlers.ts`, add the import at the top:
+
+```ts
+import { parseSpriteSpeech } from './sprite-parser'
+```
+
+Then update the `service.onData` callback (currently around line 58):
+
+```ts
+  service.onData((sessionId, data) => {
+    getWindow()?.webContents.send(`pty:data:${sessionId}`, data)
+    try {
+      const events = parseSpriteSpeech(data)
+      for (const ev of events) {
+        if (ev.type === 'speech') {
+          getWindow()?.webContents.send(IPC.SPRITE_SPEECH, { sessionId, text: ev.text })
+        }
+      }
+    } catch (err) {
+      console.error('[Sprite] Speech parse error:', err)
+    }
+  })
+```
+
+- [ ] **Step 2: Expose `onSpriteSpeech` in the preload**
+
+In `src/main/preload.ts`, add inside the `contextBridge.exposeInMainWorld('overseer', { ... })` object, after `onCompanionExit`:
+
+```ts
+  onSpriteSpeech: (callback: (payload: { sessionId: string; text: string }) => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, payload: { sessionId: string; text: string }) => callback(payload)
+    ipcRenderer.on(IPC.SPRITE_SPEECH, handler)
+    return () => ipcRenderer.removeListener(IPC.SPRITE_SPEECH, handler)
+  },
+```
+
+- [ ] **Step 3: Add `onSpriteSpeech` to `window.overseer` type declaration**
+
+In `src/renderer/types/electron.d.ts`, add inside the `overseer` interface, after `onCompanionExit`:
+
+```ts
+      onSpriteSpeech: (callback: (payload: { sessionId: string; text: string }) => void) => () => void
+```
+
+- [ ] **Step 4: Verify TypeScript compiles**
+
+```bash
+npx tsc -p tsconfig.main.json --noEmit
+```
+
+Expected: No errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/ipc-handlers.ts src/main/preload.ts src/renderer/types/electron.d.ts
+git commit -m "feat(sprite): wire side-channel speech parsing and expose onSpriteSpeech IPC"
+```
+
+---
+
+## Task 6: Persona injection in session service
+
+**Files:**
+- Modify: `src/main/session-service/index.ts`
+
+- [ ] **Step 1: Update `create()` to accept and store persona**
+
+In `src/main/session-service/index.ts`, update the `create` method:
+
+```ts
+  create(options: CreateSessionOptions): Session {
+    const id = randomUUID()
+    const envVars = readAgentEnvVars(options.agentType)
+    if (options.persona) {
+      envVars['OVERSEER_SPRITE_PERSONA'] = options.persona
+    }
+    const session: Session = {
+      id,
+      name: options.name,
+      agentType: options.agentType,
+      cwd: options.cwd || os.homedir(),
+      envVars,
+      scrollbackPath: path.join(os.homedir(), '.overseer', 'sessions', `${id}.log`),
+      spriteId: options.spriteId ?? null,
+    }
+    this.registry.add(session)
+    this.spawnPty(session)
+    return session
+  }
+```
+
+- [ ] **Step 2: Auto-start claude with persona if agentType is `claude`**
+
+Update the `spawnPty` method to write the startup command after spawn:
+
+```ts
+  private spawnPty(session: Session): void {
+    this.ptyManager.spawn(
+      session,
+      (data) => { this.onDataCallback?.(session.id, data) },
+      (err)  => { this.onErrorCallback?.(session.id, err) }
+    )
+    const persona = session.envVars['OVERSEER_SPRITE_PERSONA']
+    if (persona && session.agentType === 'claude') {
+      const escaped = persona
+        .replace(/\\/g, '\\\\')
+        .replace(/"/g, '\\"')
+        .replace(/\n/g, ' ')
+      setTimeout(() => {
+        try {
+          this.ptyManager.write(session.id, `claude --system-prompt "${escaped}"\r`)
+        } catch (err) {
+          console.error(`[Sprite] Persona injection failed for session ${session.id}:`, err)
+        }
+      }, 300)
+    }
+  }
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+```bash
+npx tsc -p tsconfig.main.json --noEmit
+```
+
+Expected: No errors.
+
+- [ ] **Step 4: Run existing tests**
+
+```bash
+npx jest tests/main/ --no-coverage
+```
+
+Expected: All main-process tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/session-service/index.ts
+git commit -m "feat(sprite): inject sprite persona into session envVars and auto-start claude"
+```
+
+---
+
+## Task 7: NewSessionDialog sprite selector
+
+**Files:**
+- Modify: `src/renderer/components/NewSessionDialog.tsx`
+
+- [ ] **Step 1: Update `NewSessionDialog` to show a sprite dropdown and pass `spriteId`/`persona` to `onCreate`**
+
+Replace the contents of `src/renderer/components/NewSessionDialog.tsx` with:
+
+```tsx
+import React, { useState, useEffect } from 'react'
+import type { CreateSessionOptions, Session } from '../types/ipc'
+import { useSpritesStore } from '../store/sprites'
+
+interface Props {
+  onCreate: (options: CreateSessionOptions) => void
+  onCancel: () => void
+}
+
+export function NewSessionDialog({ onCreate, onCancel }: Props) {
+  const [name, setName] = useState('')
+  const [agentType, setAgentType] = useState<Session['agentType']>('shell')
+  const [cwd, setCwd] = useState('')
+  const [cwdValid, setCwdValid] = useState<boolean | null>(null)
+  const [selectedSpriteId, setSelectedSpriteId] = useState<string>('')
+  const sprites = useSpritesStore(s => s.sprites)
+
+  useEffect(() => {
+    setCwdValid(null)
+    if (!cwd) return
+    const timer = setTimeout(async () => {
+      const valid = await window.overseer.isDirectory(cwd)
+      setCwdValid(valid)
+    }, 400)
+    return () => clearTimeout(timer)
+  }, [cwd])
+
+  const handleBrowse = async () => {
+    const chosen = await window.overseer.openDirectory(cwd)
+    if (chosen) setCwd(chosen)
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    const sprite = sprites.find(s => s.id === selectedSpriteId)
+    onCreate({
+      name,
+      agentType,
+      cwd,
+      spriteId: sprite?.id ?? null,
+      persona: sprite?.persona,
+    })
+  }
+
+  const overlayStyle: React.CSSProperties = {
+    position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.6)',
+    display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 100,
+  }
+  const dialogStyle: React.CSSProperties = {
+    background: 'var(--bg-header)', padding: '24px', borderRadius: '8px',
+    display: 'flex', flexDirection: 'column', gap: '16px', minWidth: '360px',
+  }
+  const labelStyle: React.CSSProperties = { color: 'var(--text-main)', display: 'flex', flexDirection: 'column', gap: '4px' }
+  const inputStyle: React.CSSProperties = { background: 'var(--bg-main)', color: 'var(--text-main)', border: '1px solid var(--border)', borderRadius: '4px', padding: '6px 8px' }
+  const cwdInputStyle: React.CSSProperties = {
+    ...inputStyle,
+    flex: 1,
+    border: cwdValid === false ? '1px solid #e05252' : '1px solid var(--border)',
+  }
+
+  return (
+    <div style={overlayStyle}>
+      <form style={dialogStyle} onSubmit={handleSubmit}>
+        <h2 style={{ color: 'var(--text-main)', margin: 0 }}>New Session</h2>
+        <label style={labelStyle} htmlFor="session-name">
+          Name
+          <input id="session-name" aria-label="Name" style={inputStyle} value={name} onChange={e => setName(e.target.value)} required autoFocus />
+        </label>
+        <label style={labelStyle} htmlFor="agent-type">
+          Agent
+          <select id="agent-type" aria-label="Agent" style={inputStyle} value={agentType} onChange={e => setAgentType(e.target.value as Session['agentType'])}>
+            <option value="claude">Claude</option>
+            <option value="gemini">Gemini</option>
+            <option value="cursor">Cursor</option>
+            <option value="shell">Shell</option>
+          </select>
+        </label>
+        <label style={labelStyle} htmlFor="cwd">
+          Working Directory
+          <div style={{ display: 'flex', gap: '6px' }}>
+            <input id="cwd" aria-label="Working Directory" style={cwdInputStyle} value={cwd} onChange={e => setCwd(e.target.value)} />
+            <button type="button" onClick={handleBrowse} style={{ ...inputStyle, cursor: 'pointer', whiteSpace: 'nowrap' }}>Browse</button>
+          </div>
+          {cwdValid === false && <span style={{ color: '#e05252', fontSize: '12px' }}>Directory not found</span>}
+        </label>
+        <label style={labelStyle} htmlFor="sprite-select">
+          Sprite <span style={{ color: 'var(--text-muted)', fontWeight: 'normal' }}>(optional)</span>
+          <select id="sprite-select" aria-label="Sprite" style={inputStyle} value={selectedSpriteId} onChange={e => setSelectedSpriteId(e.target.value)}>
+            <option value="">None</option>
+            {sprites.map(s => (
+              <option key={s.id} value={s.id}>{s.name}</option>
+            ))}
+          </select>
+        </label>
+        <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
+          <button type="button" onClick={onCancel} style={{ ...inputStyle, cursor: 'pointer' }}>Cancel</button>
+          <button type="submit" style={{ ...inputStyle, background: 'var(--accent)', color: '#fff', cursor: 'pointer' }}>Create</button>
+        </div>
+      </form>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Run existing `NewSessionDialog` tests**
+
+```bash
+npx jest tests/renderer/NewSessionDialog.test.tsx --no-coverage
+```
+
+Expected: All tests still pass. The new sprite field has a default of "None" so existing test assertions (which don't set a sprite) will pass `spriteId: null, persona: undefined`.
+
+Note: if tests fail because `useSpritesStore` tries to access `localStorage` before it is set up, add this to the test `beforeEach`:
+```ts
+(window as any).localStorage = { getItem: jest.fn(() => null), setItem: jest.fn(), removeItem: jest.fn() }
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/renderer/components/NewSessionDialog.tsx
+git commit -m "feat(sprite): add sprite selector to NewSessionDialog"
+```
+
+---
+
+## Task 8: RightSidebar + GitPanel refactor
+
+**Files:**
+- Modify: `src/renderer/components/GitPanel.tsx`
+- Create: `src/renderer/components/RightSidebar.tsx`
+
+- [ ] **Step 1: Remove self-owned width and borderLeft from GitPanel**
+
+In `src/renderer/components/GitPanel.tsx`, update `panelStyle`:
+
+```ts
+  const panelStyle: React.CSSProperties = {
+    flex: 1, background: 'var(--bg-sidebar)', display: 'flex', flexDirection: 'column',
+    padding: '12px', gap: '8px',
+  }
+```
+
+(Removed `width: '260px'` and `borderLeft: '1px solid var(--border)'` — these are now owned by `RightSidebar`.)
+
+- [ ] **Step 2: Run GitPanel tests to confirm no regression**
+
+```bash
+npx jest tests/renderer/GitPanel.test.tsx --no-coverage
+```
+
+Expected: All tests pass (they test behavior, not CSS).
+
+- [ ] **Step 3: Create RightSidebar**
+
+Create `src/renderer/components/RightSidebar.tsx`:
+
+```tsx
+import React from 'react'
+import { GitPanel } from './GitPanel'
+import { SpritePanel } from './SpritePanel'
+import type { Session } from '../types/ipc'
+
+interface Props {
+  activeSession: Session | undefined
+  spritePanelVisible: boolean
+  onOpenStudio: () => void
+}
+
+export function RightSidebar({ activeSession, spritePanelVisible, onOpenStudio }: Props) {
+  if (!activeSession) return null
+
+  return (
+    <div style={{
+      width: '260px',
+      background: 'var(--bg-sidebar)',
+      borderLeft: '1px solid var(--border)',
+      display: 'flex',
+      flexDirection: 'column',
+      overflow: 'hidden',
+    }}>
+      <GitPanel cwd={activeSession.cwd} />
+      <SpritePanel
+        sessionId={activeSession.id}
+        spriteId={activeSession.spriteId ?? null}
+        animationState="idle"
+        visible={spritePanelVisible}
+        onOpenStudio={onOpenStudio}
+      />
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Verify TypeScript compiles**
+
+```bash
+npx tsc -p tsconfig.main.json --noEmit
+```
+
+Expected: No errors (SpritePanel will be missing until Task 9 — if tsc errors on SpritePanel import, stub it temporarily with an empty component).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/components/GitPanel.tsx src/renderer/components/RightSidebar.tsx
+git commit -m "feat(sprite): extract RightSidebar and refactor GitPanel layout ownership"
+```
+
+---
+
+## Task 9: SpritePanel component + tests
+
+**Files:**
+- Create: `src/renderer/components/SpritePanel.tsx`
+- Create: `tests/renderer/SpritePanel.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/renderer/SpritePanel.test.tsx`:
+
+```tsx
+import React from 'react'
+import { render, screen, act } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { SpritePanel } from '../../src/renderer/components/SpritePanel'
+import { useSpritesStore } from '../../src/renderer/store/sprites'
+
+jest.mock('@dicebear/core', () => ({
+  createAvatar: jest.fn(() => ({ toString: () => '<svg data-testid="mock-avatar"></svg>' })),
+}))
+jest.mock('@dicebear/collection', () => ({ bottts: {} }))
+
+beforeEach(() => {
+  localStorage.clear()
+  useSpritesStore.setState({ sprites: [] })
+  ;(window as any).overseer = {
+    onSpriteSpeech: jest.fn().mockReturnValue(() => {}),
+  }
+})
+
+test('renders empty state when spriteId is null', () => {
+  render(<SpritePanel sessionId="s1" spriteId={null} animationState="idle" visible={true} onOpenStudio={() => {}} />)
+  expect(screen.getByText('No Sprite assigned')).toBeInTheDocument()
+  expect(screen.getByText('Open Studio')).toBeInTheDocument()
+})
+
+test('renders nothing when visible is false', () => {
+  render(<SpritePanel sessionId="s1" spriteId={null} animationState="idle" visible={false} onOpenStudio={() => {}} />)
+  expect(screen.queryByText('No Sprite assigned')).not.toBeInTheDocument()
+})
+
+test('renders avatar when spriteId matches a sprite in store', () => {
+  const { createSprite } = useSpritesStore.getState()
+  const sprite = createSprite({ name: 'Salty', style: 'bottts', seed: 'sailor', persona: '' })
+  render(<SpritePanel sessionId="s1" spriteId={sprite.id} animationState="idle" visible={true} onOpenStudio={() => {}} />)
+  expect(screen.getByText(/Salty/)).toBeInTheDocument()
+})
+
+test('renders empty state when spriteId does not match any sprite', () => {
+  render(<SpritePanel sessionId="s1" spriteId="nonexistent-id" animationState="idle" visible={true} onOpenStudio={() => {}} />)
+  expect(screen.getByText('No Sprite assigned')).toBeInTheDocument()
+})
+
+test('subscribes to onSpriteSpeech with the session id', () => {
+  render(<SpritePanel sessionId="s1" spriteId={null} animationState="idle" visible={true} onOpenStudio={() => {}} />)
+  expect((window as any).overseer.onSpriteSpeech).toHaveBeenCalled()
+})
+
+test('displays speech text when onSpriteSpeech fires for matching session', async () => {
+  let capturedCb: ((p: { sessionId: string; text: string }) => void) | null = null
+  ;(window as any).overseer.onSpriteSpeech = jest.fn().mockImplementation(cb => {
+    capturedCb = cb
+    return () => {}
+  })
+  render(<SpritePanel sessionId="s1" spriteId={null} animationState="idle" visible={true} onOpenStudio={() => {}} />)
+
+  await act(async () => {
+    capturedCb?.({ sessionId: 's1', text: 'hello sailor' })
+  })
+
+  expect(screen.getByText('hello sailor')).toBeInTheDocument()
+})
+
+test('does not display speech for a different session', async () => {
+  let capturedCb: ((p: { sessionId: string; text: string }) => void) | null = null
+  ;(window as any).overseer.onSpriteSpeech = jest.fn().mockImplementation(cb => {
+    capturedCb = cb
+    return () => {}
+  })
+  render(<SpritePanel sessionId="s1" spriteId={null} animationState="idle" visible={true} onOpenStudio={() => {}} />)
+
+  await act(async () => {
+    capturedCb?.({ sessionId: 'OTHER', text: 'not for me' })
+  })
+
+  expect(screen.queryByText('not for me')).not.toBeInTheDocument()
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npx jest tests/renderer/SpritePanel.test.tsx --no-coverage
+```
+
+Expected: Tests fail with "Cannot find module '../../src/renderer/components/SpritePanel'".
+
+- [ ] **Step 3: Implement SpritePanel**
+
+Create `src/renderer/components/SpritePanel.tsx`:
+
+```tsx
+import React, { useEffect, useState, useRef } from 'react'
+import { createAvatar } from '@dicebear/core'
+import { bottts } from '@dicebear/collection'
+import { useSpritesStore } from '../store/sprites'
+
+interface Props {
+  sessionId: string | null
+  spriteId: string | null
+  animationState: 'idle' | 'talking' | 'thinking'  // no-op in MVP; prop exists for future extension
+  visible: boolean
+  onOpenStudio: () => void
+}
+
+export function SpritePanel({ sessionId, spriteId, animationState: _animationState, visible, onOpenStudio }: Props) {
+  const sprites = useSpritesStore(s => s.sprites)
+  const sprite = spriteId ? (sprites.find(s => s.id === spriteId) ?? null) : null
+  const [speechText, setSpeechText] = useState('')
+  const clearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    if (!sessionId) return
+    const unsub = window.overseer.onSpriteSpeech(({ sessionId: sid, text }) => {
+      if (sid !== sessionId) return
+      setSpeechText(text)
+      if (clearTimerRef.current) clearTimeout(clearTimerRef.current)
+      clearTimerRef.current = setTimeout(() => setSpeechText(''), 8000)
+    })
+    return () => {
+      unsub()
+      if (clearTimerRef.current) clearTimeout(clearTimerRef.current)
+    }
+  }, [sessionId])
+
+  if (!visible) return null
+
+  let avatarSvg = ''
+  if (sprite) {
+    try {
+      avatarSvg = createAvatar(bottts, { seed: sprite.seed }).toString()
+    } catch (err) {
+      console.error(`[Sprite] Avatar render failed for sprite ${sprite.id}:`, err)
+    }
+  }
+
+  const containerStyle: React.CSSProperties = {
+    borderTop: '1px solid var(--border)',
+    padding: '12px',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: '8px',
+    minHeight: '160px',
+  }
+  const labelStyle: React.CSSProperties = {
+    color: 'var(--text-muted)', fontSize: '11px', textTransform: 'uppercase', letterSpacing: '0.08em', alignSelf: 'flex-start',
+  }
+
+  if (!sprite) {
+    return (
+      <div style={containerStyle}>
+        <div style={labelStyle}>Sprite</div>
+        <div style={{ color: 'var(--text-muted)', fontSize: '12px', textAlign: 'center' }}>No Sprite assigned</div>
+        <button
+          onClick={onOpenStudio}
+          style={{ background: 'var(--accent)', color: '#fff', border: 'none', borderRadius: '4px', padding: '6px 12px', cursor: 'pointer', fontSize: '12px' }}
+        >
+          Open Studio
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div style={containerStyle}>
+      <div style={labelStyle}>Sprite — {sprite.name}</div>
+      {speechText && (
+        <div style={{
+          background: 'var(--bg-main)',
+          border: '1px solid var(--border)',
+          borderRadius: '8px',
+          padding: '8px 10px',
+          fontSize: '12px',
+          color: 'var(--text-main)',
+          maxWidth: '220px',
+          textAlign: 'center',
+        }}>
+          {speechText}
+        </div>
+      )}
+      {avatarSvg && (
+        <div
+          style={{ width: '80px', height: '80px' }}
+          dangerouslySetInnerHTML={{ __html: avatarSvg }}
+        />
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npx jest tests/renderer/SpritePanel.test.tsx --no-coverage
+```
+
+Expected: All 7 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/components/SpritePanel.tsx tests/renderer/SpritePanel.test.tsx
+git commit -m "feat(sprite): add SpritePanel component with speech bubble and empty state"
+```
+
+---
+
+## Task 10: SpriteStudio component + tests
+
+**Files:**
+- Create: `src/renderer/components/SpriteStudio.tsx`
+- Create: `tests/renderer/SpriteStudio.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/renderer/SpriteStudio.test.tsx`:
+
+```tsx
+import React from 'react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { SpriteStudio } from '../../src/renderer/components/SpriteStudio'
+import { useSpritesStore } from '../../src/renderer/store/sprites'
+
+jest.mock('@dicebear/core', () => ({
+  createAvatar: jest.fn(() => ({ toString: () => '<svg></svg>' })),
+}))
+jest.mock('@dicebear/collection', () => ({ bottts: {} }))
+
+beforeEach(() => {
+  localStorage.clear()
+  useSpritesStore.setState({ sprites: [] })
+  jest.useFakeTimers()
+})
+
+afterEach(() => {
+  jest.useRealTimers()
+})
+
+test('renders "New Sprite" heading when no editingId', () => {
+  render(<SpriteStudio onClose={() => {}} />)
+  expect(screen.getByText('New Sprite')).toBeInTheDocument()
+})
+
+test('renders "Edit Sprite" heading when editingId provided', () => {
+  const { createSprite } = useSpritesStore.getState()
+  const sprite = createSprite({ name: 'Salty', style: 'bottts', seed: 'sailor', persona: 'grumpy' })
+  render(<SpriteStudio onClose={() => {}} editingId={sprite.id} />)
+  expect(screen.getByText('Edit Sprite')).toBeInTheDocument()
+})
+
+test('calls onClose when Cancel is clicked', () => {
+  const onClose = jest.fn()
+  render(<SpriteStudio onClose={onClose} />)
+  fireEvent.click(screen.getByText('Cancel'))
+  expect(onClose).toHaveBeenCalled()
+})
+
+test('creates a new sprite and calls onClose on Save', () => {
+  const onClose = jest.fn()
+  render(<SpriteStudio onClose={onClose} />)
+  fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Salty' } })
+  fireEvent.change(screen.getByLabelText('Avatar Seed'), { target: { value: 'sailor123' } })
+  fireEvent.change(screen.getByLabelText('Persona'), { target: { value: 'grumpy old sailor' } })
+  fireEvent.click(screen.getByText('Save'))
+  expect(onClose).toHaveBeenCalled()
+  const sprites = useSpritesStore.getState().sprites
+  expect(sprites).toHaveLength(1)
+  expect(sprites[0].name).toBe('Salty')
+  expect(sprites[0].seed).toBe('sailor123')
+  expect(sprites[0].persona).toBe('grumpy old sailor')
+  expect(sprites[0].style).toBe('bottts')
+})
+
+test('updates an existing sprite on Save', () => {
+  const { createSprite } = useSpritesStore.getState()
+  const sprite = createSprite({ name: 'Salty', style: 'bottts', seed: 'sailor', persona: 'grumpy' })
+  const onClose = jest.fn()
+  render(<SpriteStudio onClose={onClose} editingId={sprite.id} />)
+  fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Salty McSaltface' } })
+  fireEvent.click(screen.getByText('Save'))
+  expect(onClose).toHaveBeenCalled()
+  expect(useSpritesStore.getState().sprites[0].name).toBe('Salty McSaltface')
+})
+
+test('Delete requires confirmation and auto-cancels after 2s', async () => {
+  const { createSprite } = useSpritesStore.getState()
+  const sprite = createSprite({ name: 'Salty', style: 'bottts', seed: 'sailor', persona: '' })
+  render(<SpriteStudio onClose={() => {}} editingId={sprite.id} />)
+
+  fireEvent.click(screen.getByText('Delete'))
+  expect(screen.getByText('Confirm Delete')).toBeInTheDocument()
+  expect(useSpritesStore.getState().sprites).toHaveLength(1)
+
+  await act(async () => { jest.advanceTimersByTime(2000) })
+
+  expect(screen.getByText('Delete')).toBeInTheDocument()
+  expect(screen.queryByText('Confirm Delete')).not.toBeInTheDocument()
+})
+
+test('Delete removes sprite when confirmed', () => {
+  const { createSprite } = useSpritesStore.getState()
+  const sprite = createSprite({ name: 'Salty', style: 'bottts', seed: 'sailor', persona: '' })
+  const onClose = jest.fn()
+  render(<SpriteStudio onClose={onClose} editingId={sprite.id} />)
+
+  fireEvent.click(screen.getByText('Delete'))
+  fireEvent.click(screen.getByText('Confirm Delete'))
+
+  expect(onClose).toHaveBeenCalled()
+  expect(useSpritesStore.getState().sprites).toHaveLength(0)
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npx jest tests/renderer/SpriteStudio.test.tsx --no-coverage
+```
+
+Expected: Tests fail with "Cannot find module '../../src/renderer/components/SpriteStudio'".
+
+- [ ] **Step 3: Implement SpriteStudio**
+
+Create `src/renderer/components/SpriteStudio.tsx`:
+
+```tsx
+import React, { useState } from 'react'
+import { createAvatar } from '@dicebear/core'
+import { bottts } from '@dicebear/collection'
+import { useSpritesStore } from '../store/sprites'
+
+interface Props {
+  onClose: () => void
+  editingId?: string | null
+}
+
+export function SpriteStudio({ onClose, editingId }: Props) {
+  const { sprites, createSprite, updateSprite, deleteSprite } = useSpritesStore()
+  const editing = editingId ? (sprites.find(s => s.id === editingId) ?? null) : null
+
+  const [name, setName] = useState(editing?.name ?? '')
+  const [seed, setSeed] = useState(editing?.seed ?? '')
+  const [persona, setPersona] = useState(editing?.persona ?? '')
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const deleteTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  let previewSvg = ''
+  if (seed) {
+    try {
+      previewSvg = createAvatar(bottts, { seed }).toString()
+    } catch (err) {
+      console.error('[Sprite] Avatar preview render failed:', err)
+    }
+  }
+
+  const handleSave = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!name.trim()) return
+    if (editing) {
+      updateSprite(editing.id, { name: name.trim(), seed, persona })
+    } else {
+      createSprite({ name: name.trim(), style: 'bottts', seed, persona })
+    }
+    onClose()
+  }
+
+  const handleDelete = () => {
+    if (!editing) return
+    if (confirmDelete) {
+      if (deleteTimerRef.current) clearTimeout(deleteTimerRef.current)
+      deleteSprite(editing.id)
+      onClose()
+    } else {
+      setConfirmDelete(true)
+      deleteTimerRef.current = setTimeout(() => setConfirmDelete(false), 2000)
+    }
+  }
+
+  const overlayStyle: React.CSSProperties = {
+    position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.6)',
+    display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 100,
+  }
+  const dialogStyle: React.CSSProperties = {
+    background: 'var(--bg-header)', padding: '24px', borderRadius: '8px',
+    display: 'flex', flexDirection: 'column', gap: '16px', minWidth: '420px', maxWidth: '560px', width: '100%',
+  }
+  const inputStyle: React.CSSProperties = {
+    background: 'var(--bg-main)', color: 'var(--text-main)', border: '1px solid var(--border)',
+    borderRadius: '4px', padding: '6px 8px', width: '100%', boxSizing: 'border-box',
+  }
+  const labelStyle: React.CSSProperties = {
+    color: 'var(--text-main)', display: 'flex', flexDirection: 'column', gap: '4px',
+  }
+
+  return (
+    <div style={overlayStyle}>
+      <form style={dialogStyle} onSubmit={handleSave}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <h2 style={{ color: 'var(--text-main)', margin: 0 }}>{editing ? 'Edit Sprite' : 'New Sprite'}</h2>
+          <button type="button" onClick={onClose} style={{ background: 'transparent', border: 'none', color: 'var(--text-muted)', cursor: 'pointer', fontSize: '18px' }}>✕</button>
+        </div>
+
+        <label style={labelStyle} htmlFor="sprite-name">
+          Name
+          <input id="sprite-name" aria-label="Name" style={inputStyle} value={name} onChange={e => setName(e.target.value)} required autoFocus />
+        </label>
+
+        <label style={labelStyle} htmlFor="sprite-seed">
+          Avatar Seed
+          <input id="sprite-seed" aria-label="Avatar Seed" style={inputStyle} value={seed} onChange={e => setSeed(e.target.value)} placeholder="Any text — changes the avatar shape" />
+        </label>
+
+        {previewSvg && (
+          <div style={{ display: 'flex', justifyContent: 'center' }}>
+            <div style={{ width: '80px', height: '80px' }} dangerouslySetInnerHTML={{ __html: previewSvg }} />
+          </div>
+        )}
+
+        <label style={labelStyle} htmlFor="sprite-persona">
+          Persona
+          <textarea
+            id="sprite-persona"
+            aria-label="Persona"
+            style={{ ...inputStyle, minHeight: '80px', resize: 'vertical', fontFamily: 'inherit' }}
+            value={persona}
+            onChange={e => setPersona(e.target.value)}
+            placeholder="Describe the character personality..."
+          />
+        </label>
+
+        <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end', flexWrap: 'wrap' }}>
+          {editing && (
+            <button
+              type="button"
+              onClick={handleDelete}
+              style={{
+                background: confirmDelete ? '#c0392b' : 'transparent',
+                color: confirmDelete ? '#fff' : '#e05252',
+                border: '1px solid #e05252',
+                borderRadius: '4px', padding: '6px 12px', cursor: 'pointer',
+              }}
+            >
+              {confirmDelete ? 'Confirm Delete' : 'Delete'}
+            </button>
+          )}
+          <button type="button" onClick={onClose} style={{ background: 'transparent', color: 'var(--text-main)', border: '1px solid var(--border)', borderRadius: '4px', padding: '6px 12px', cursor: 'pointer' }}>Cancel</button>
+          <button type="submit" style={{ background: 'var(--accent)', color: '#fff', border: 'none', borderRadius: '4px', padding: '6px 12px', cursor: 'pointer' }}>Save</button>
+        </div>
+      </form>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npx jest tests/renderer/SpriteStudio.test.tsx --no-coverage
+```
+
+Expected: All 7 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/components/SpriteStudio.tsx tests/renderer/SpriteStudio.test.tsx
+git commit -m "feat(sprite): add SpriteStudio create/edit modal"
+```
+
+---
+
+## Task 11: Keybindings + App.tsx wiring
+
+**Files:**
+- Modify: `src/renderer/hooks/useKeyboardShortcuts.ts`
+- Modify: `src/renderer/components/KeyboardShortcutsModal.tsx`
+- Modify: `src/renderer/App.tsx`
+
+- [ ] **Step 1: Add handlers to `useKeyboardShortcuts`**
+
+In `src/renderer/hooks/useKeyboardShortcuts.ts`, update `ShortcutHandlers` interface to add:
+
+```ts
+export interface ShortcutHandlers {
+  // ... existing handlers ...
+  onToggleSpritePanel: () => void
+  onOpenSpriteStudio:  () => void
+}
+```
+
+In the `handleKeyDown` function, add after `splitToggleDirection`:
+
+```ts
+      if (action === 'toggleSpritePanel') { h.onToggleSpritePanel(); return }
+      if (action === 'openSpriteStudio')  { h.onOpenSpriteStudio();  return }
+```
+
+- [ ] **Step 2: Add sprite actions to KeyboardShortcutsModal**
+
+In `src/renderer/components/KeyboardShortcutsModal.tsx`, add to `ACTION_LABELS`:
+
+```ts
+  toggleSpritePanel: 'Toggle Sprite Panel',
+  openSpriteStudio:  'Open Sprite Studio',
+```
+
+Add a new group to `GROUPS`:
+
+```ts
+  {
+    title: 'SPRITE',
+    actions: ['toggleSpritePanel', 'openSpriteStudio']
+  }
+```
+
+- [ ] **Step 3: Wire up App.tsx**
+
+In `src/renderer/App.tsx`:
+
+1. Replace `import { GitPanel } from './components/GitPanel'` with:
+```ts
+import { RightSidebar } from './components/RightSidebar'
+import { SpriteStudio } from './components/SpriteStudio'
+```
+
+2. Add state variables inside `App()`:
+```ts
+  const [showSpriteStudio, setShowSpriteStudio] = useState(false)
+  const [spriteStudioEditId, setSpriteStudioEditId] = useState<string | null>(null)
+  const [spritePanelVisible, setSpritePanelVisible] = useState(true)
+```
+
+3. In the `useKeyboardShortcuts` call, add the new handlers:
+```ts
+    onToggleSpritePanel: () => setSpritePanelVisible(v => !v),
+    onOpenSpriteStudio:  () => { setSpriteStudioEditId(null); setShowSpriteStudio(true) },
+```
+
+4. In the JSX, replace:
+```tsx
+        {activeSession && <GitPanel cwd={activeSession.cwd} />}
+```
+with:
+```tsx
+        <RightSidebar
+          activeSession={activeSession}
+          spritePanelVisible={spritePanelVisible}
+          onOpenStudio={() => { setSpriteStudioEditId(null); setShowSpriteStudio(true) }}
+        />
+```
+
+5. Add the `SpriteStudio` modal at the bottom of the JSX (after the `KeyboardShortcutsModal` block):
+```tsx
+      {showSpriteStudio && (
+        <SpriteStudio
+          onClose={() => setShowSpriteStudio(false)}
+          editingId={spriteStudioEditId}
+        />
+      )}
+```
+
+- [ ] **Step 4: Verify TypeScript compiles**
+
+```bash
+npx tsc -p tsconfig.main.json --noEmit
+```
+
+Expected: No errors.
+
+- [ ] **Step 5: Run all tests**
+
+```bash
+npx jest --no-coverage
+```
+
+Expected: All tests pass. If `App-shortcuts-toggle.test.tsx` fails because it mocks `GitPanel` but not `RightSidebar`, add a mock:
+```ts
+jest.mock('../../src/renderer/components/RightSidebar', () => ({
+  RightSidebar: () => <div data-testid="right-sidebar" />
+}))
+```
+And remove the `GitPanel` mock since it's no longer imported by App.tsx directly.
+
+Also add `onToggleSpritePanel: jest.fn()` and `onOpenSpriteStudio: jest.fn()` to any mock `useKeyboardShortcuts` setup if the test mocks that hook.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/renderer/hooks/useKeyboardShortcuts.ts src/renderer/components/KeyboardShortcutsModal.tsx src/renderer/App.tsx
+git commit -m "feat(sprite): wire keybindings and integrate RightSidebar + SpriteStudio into App"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- ✓ Sprite Studio (create/edit/delete) — Task 10
+- ✓ Sprite assigned per session at creation — Tasks 3, 6, 7
+- ✓ Persona injected at session start — Task 6
+- ✓ Speech bubble from `<speak>` tags — Tasks 2, 5, 9
+- ✓ Side-channel parsing (raw PTY stream untouched) — Tasks 2, 5
+- ✓ DiceBear avatar (`bottts`) — Tasks 9, 10
+- ✓ Keybindings (`toggleSpritePanel`, `openSpriteStudio`) — Tasks 3, 11
+- ✓ RightSidebar refactor — Task 8
+- ✓ Error handling with `[Sprite]` prefix console logs — Tasks 2, 5, 6, 9, 10
+- ✓ `animationState` prop as no-op placeholder — Task 9
+- ✓ Post-MVP structure (extensible `ParsedSpriteEvent[]`, `animationState` prop) — Tasks 2, 9
+
+**Type consistency check:**
+- `parseSpriteSpeech` defined Task 2, used Task 5 ✓
+- `ParsedSpriteEvent.type === 'speech'` consistent across Tasks 2 and 5 ✓
+- `Sprite` interface defined Task 4, used in Tasks 7, 9, 10 ✓
+- `Session.spriteId` defined Task 3, used in Tasks 6, 8, 9 ✓
+- `CreateSessionOptions.spriteId / persona` defined Task 3, used in Tasks 6, 7 ✓
+- `onSpriteSpeech` preload signature Task 5, electron.d.ts Task 5, usage Task 9 ✓
+- `IPC.SPRITE_SPEECH` defined Task 3, used in Tasks 5 (ipc-handlers + preload) ✓
+- `KeybindingAction toggleSpritePanel / openSpriteStudio` Task 3, handlers Task 11 ✓

--- a/docs/superpowers/specs/2026-04-28-sprite-design.md
+++ b/docs/superpowers/specs/2026-04-28-sprite-design.md
@@ -1,0 +1,218 @@
+# Sprite Feature Design
+
+**Date:** 2026-04-28  
+**Status:** Approved  
+
+## Summary
+
+A character companion ("Sprite") that sits in the right sidebar and reacts to AI terminal output via speech bubbles. Each session is assigned a Sprite at creation time; the Sprite's persona is injected into the AI's system prompt at spawn. The feature is entirely optional and must not interfere with normal terminal UX.
+
+---
+
+## Architecture Overview
+
+### Layers
+
+**Main process**
+- `src/main/sprite-parser.ts` — pure function `parseSpriteSpeech(chunk: string)` extracts `<speak>…</speak>` content from raw PTY data
+- `src/main/pty-manager.ts` — calls `parseSpriteSpeech` in `onData`, emits `companion:sprite-speech` IPC event with `{ sessionId, text }` when speech is found; raw stream is untouched
+- Agent spawn logic — prepends the Sprite's persona to the system prompt when the session has a `spriteId`
+
+**Renderer**
+- `src/renderer/store/sprites.ts` — Zustand store persisted to localStorage; holds Sprite definitions and active-session Sprite mapping
+- `src/renderer/components/RightSidebar.tsx` — wraps the existing GitPanel and the new SpritePanel in a single right-column container
+- `src/renderer/components/SpritePanel.tsx` — renders avatar, speech bubble, empty state; subscribes to `companion:sprite-speech`
+- `src/renderer/components/SpriteStudio.tsx` — modal for creating and editing Sprites
+
+**Preload / IPC**
+- `src/preload/ipc.ts` — exposes `onSpriteSpeech(cb)` to the renderer
+
+### Key constraint
+Tags are **not** stripped from the PTY stream. They appear as plaintext in the xterm terminal. This is an accepted MVP tradeoff — stripping is a post-MVP option once the side-channel parsing is proven stable.
+
+---
+
+## Component Breakdown
+
+### `sprites` Zustand store (`src/renderer/store/sprites.ts`)
+```ts
+interface Sprite {
+  id: string           // uuid
+  name: string
+  style: string        // DiceBear collection key — MVP: 'bottts'
+  seed: string         // DiceBear seed string
+  persona: string      // freeform text injected as system prompt prefix
+}
+
+interface SpritesState {
+  sprites: Sprite[]
+  createSprite(s: Omit<Sprite, 'id'>): void
+  updateSprite(id: string, patch: Partial<Omit<Sprite, 'id'>>): void
+  deleteSprite(id: string): void
+}
+```
+Persisted to localStorage via Zustand `persist` middleware, same pattern as the theme store.
+
+### `Session` type
+`spriteId: string | null` added to the session object. Set at session creation, never changed at runtime.
+
+### `RightSidebar` (`src/renderer/components/RightSidebar.tsx`)
+- Replaces the direct `<GitPanel>` render in `App.tsx`
+- Stacks GitPanel on top, SpritePanel below
+- Passes `activeSession` down to both panels
+
+### `SpritePanel` (`src/renderer/components/SpritePanel.tsx`)
+Props:
+```ts
+interface SpritePanelProps {
+  sessionId: string | null
+  spriteId: string | null
+  animationState: 'idle' | 'talking' | 'thinking'  // no-op in MVP; prop exists for future extension
+  visible: boolean
+}
+```
+Behavior:
+- No sprite assigned → renders "No Sprite assigned" empty state with a prompt to open the Studio
+- Sprite assigned → renders DiceBear SVG avatar + speech bubble with last received `<speak>` text
+- Subscribes to `window.overseer.onSpriteSpeech` filtered by `sessionId`
+- Speech bubble clears after a configurable timeout (default 8s)
+
+### `SpriteStudio` (`src/renderer/components/SpriteStudio.tsx`)
+- Full-screen modal, keyboard-navigable
+- Fields: Name, Avatar Style (MVP: `bottts` only), Seed (text input with live SVG preview), Persona (multiline textarea)
+- Create / Edit / Delete actions
+- Opened via `Ctrl+Shift+P` or from the empty state in SpritePanel
+
+### `sprite-parser.ts` (`src/main/sprite-parser.ts`)
+```ts
+interface ParsedSpriteEvent {
+  type: 'speech'
+  text: string
+}
+
+function parseSpriteSpeech(chunk: string): ParsedSpriteEvent[]
+```
+- Pure function; no side effects; testable in isolation
+- Returns array to support future tag types (`emotion`, `action`, etc.)
+- Handles multi-chunk tag splits gracefully (stateless MVP: only matches complete tags in a single chunk)
+
+---
+
+## Data Flow
+
+### Speech detection
+```
+PTY onData(chunk)
+  → parseSpriteSpeech(chunk)          // main process, pure
+  → if events found: emit IPC 'companion:sprite-speech' { sessionId, text }
+  → raw chunk forwarded to xterm unchanged
+```
+
+### Renderer subscription
+```
+window.overseer.onSpriteSpeech(({ sessionId, text }) => {
+  if (sessionId === activeSession.id) setSpeechText(text)
+})
+```
+
+### Persona injection
+```
+createSession({ spriteId, ... })
+  → look up sprite.persona from store
+  → prepend to system prompt: `[${sprite.name}]\n${sprite.persona}\n---\n`
+  → spawn PTY with modified prompt
+```
+Persona is bound at spawn time only — no runtime switching.
+
+---
+
+## Studio Modal
+
+**Layout:** Full-screen overlay (same pattern as SettingsModal).
+
+**Form fields:**
+| Field | Type | Notes |
+|-------|------|-------|
+| Name | text input | Required |
+| Avatar Style | dropdown | MVP: `bottts` only; more styles post-MVP |
+| Seed | text input | Live SVG preview updates on change |
+| Persona | textarea | Freeform; injected verbatim as system prompt prefix |
+
+**Actions:**
+- Save (create or update)
+- Delete (with confirmation — confirm state auto-clears after 2s, same pattern as session kill)
+- Cancel / close
+
+**Keyboard navigation:** Tab through fields, Enter to save, Escape to cancel. Arrow keys on avatar style dropdown.
+
+---
+
+## Keybindings
+
+| Action | Default | `KeybindingAction` key |
+|--------|---------|------------------------|
+| Toggle Sprite panel visibility | `Ctrl+Shift+S` | `toggleSpritePanel` |
+| Open Sprite Studio | `Ctrl+Shift+P` | `openSpriteStudio` |
+
+Both added to `KeybindingAction`, `DEFAULT_KEYBINDINGS`, and the shortcuts modal in the same PR. No runtime sprite-switching shortcut — runtime switching is not supported.
+
+---
+
+## Error Handling
+
+All failure paths fail silently from the user's perspective but **must log to console** with a `[Sprite]` prefix and descriptive message. No toasts or error UI — the Sprite is a gimmick and must never interrupt the main workflow.
+
+| Scenario | Behavior |
+|----------|----------|
+| DiceBear render fails | Log `[Sprite] Avatar render failed for sprite <id>: <error>`; show placeholder (empty box) |
+| `parseSpriteSpeech` throws | Log `[Sprite] Speech parse error: <error>`; skip emission, PTY stream continues unaffected |
+| IPC emission fails | Log `[Sprite] Failed to emit sprite-speech event for session <sessionId>: <error>` |
+| Sprite not found for session | Log `[Sprite] Sprite <spriteId> not found in store for session <sessionId>`; render empty state |
+| Persona injection fails | Log `[Sprite] Persona injection failed for session <sessionId>: <error>`; session spawns without persona (graceful degradation) |
+
+---
+
+## Testing
+
+### Unit
+- `parseSpriteSpeech`: complete tag in one chunk, no tag, multiple tags, malformed/unclosed tags, empty string
+- Sprite store: create, update, delete, persistence round-trip
+
+### Integration
+- PTY `onData` hook: mock chunk with `<speak>` tag → verify IPC event emitted, verify raw chunk forwarded unchanged
+- Persona injection: session with `spriteId` → verify system prompt contains persona prefix; session without `spriteId` → verify prompt unchanged
+
+### Component / smoke
+- `SpritePanel` renders empty state when `spriteId` is null
+- `SpritePanel` renders avatar + speech bubble when speech received
+- `SpriteStudio` opens, fills form, saves → sprite appears in store
+
+---
+
+## Post-MVP Roadmap
+
+These are explicitly deferred. The code is structured to support all of them without a rewrite.
+
+**Animations**
+- `SpritePanel` already accepts `animationState` prop as a no-op
+- Implement: `talking` → mouth animation during `<speak>` open/close; `thinking` → when terminal output is actively streaming; `idle` → looping background animation
+- DiceBear SVGs don't animate natively — likely requires CSS keyframes on SVG paths or a sprite sheet approach
+
+**Tag stripping from PTY output**
+- Tags currently appear as plaintext in xterm (accepted MVP tradeoff)
+- Future option: strip `<speak>…</speak>` from the rendered xterm stream after side-channel parsing is proven stable
+
+**Additional avatar styles**
+- `@dicebear/collection` ships many styles (`adventurer`, `avataaars`, `lorelei`, etc.)
+- Add a style picker to the Studio — MVP hardcodes `bottts`
+
+**Richer tag types**
+- `parseSpriteSpeech` returns `ParsedSpriteEvent[]` — array is already typed for extensibility
+- Future: `<emotion>happy</emotion>`, `<action>wave</action>` to drive animations
+
+**Sprite import/export**
+- Export a Sprite definition as JSON; import = "create from JSON" in Studio
+
+**Keyboard shortcut for session-sprite assignment**
+- Currently Sprite is bound only at session creation
+- Future: shortcut to open a "reassign sprite" picker for the active session (persona re-injected on next restart or via an explicit re-inject command)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.3.0",
       "license": "ISC",
       "dependencies": {
+        "@dicebear/collection": "^9.4.2",
+        "@dicebear/core": "^9.4.2",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
         "node-pty": "^1.1.0",
@@ -718,6 +720,435 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/@dicebear/adventurer": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/adventurer/-/adventurer-9.4.2.tgz",
+      "integrity": "sha512-jqYp834ZmGDA9HBBDQAdgF1O2UTCwHF4vVrktXWa2Dppp1JczPL5HnVOWsjtrLmXNn61Wd6OLmBb2e6rhzp3ig==",
+      "license": "(MIT AND CC-BY-4.0)",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/adventurer-neutral": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/adventurer-neutral/-/adventurer-neutral-9.4.2.tgz",
+      "integrity": "sha512-5xgkG/mNL4j3Q4SJGQLBU/KnU90tng8Ze5ofThD+55wi0oeY/nSAUowg6UFCmHrktjifj/MEx3CQqbpcPWtfIA==",
+      "license": "(MIT AND CC-BY-4.0)",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/avataaars": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/avataaars/-/avataaars-9.4.2.tgz",
+      "integrity": "sha512-3x9jKFkOkFSPmpTbt9xvhiU2E1GX7beCSsX0tXRUShj8x6+5Ks9yBRT1VlkySbnXrZ/GglADGg7vJ/D2uIx1Yw==",
+      "license": "See LICENSE file",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/avataaars-neutral": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/avataaars-neutral/-/avataaars-neutral-9.4.2.tgz",
+      "integrity": "sha512-/eNrp0YCNJRwQXqOloLm1+3Ss2C+pMpUQIGkbEnGsP1UK+13Ge80ggDDof1HpdqvG9HAZcKa7hnbG/0HSwyDSw==",
+      "license": "See LICENSE file",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/big-ears": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/big-ears/-/big-ears-9.4.2.tgz",
+      "integrity": "sha512-mNfz3ppNA7UBq0IO3nXCiV5pFPG7c1DfzRB0foNU2Wo1XXT8FIcSY2BvDlYqorZTOUOz7dHb0vx06hqvG0HP5w==",
+      "license": "(MIT AND CC-BY-4.0)",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/big-ears-neutral": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/big-ears-neutral/-/big-ears-neutral-9.4.2.tgz",
+      "integrity": "sha512-M8Ozmzza4eY4hpLOYULgJxMYmBA0CsBnrE15/xw6LZkEREXnrX5z0NJsf8hUfdyF6BWZ+RBgzoiav32DAC5zcg==",
+      "license": "(MIT AND CC-BY-4.0)",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/big-smile": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/big-smile/-/big-smile-9.4.2.tgz",
+      "integrity": "sha512-hmT5i7rcPPhStjZyg28pbIhdTnnMBzK3RObI0vKCpY30EFrzaPkkdDL6Ck5fAFBdvDIW1EpOJkenyR0XPmhgbQ==",
+      "license": "(MIT AND CC-BY-4.0)",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/bottts": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/bottts/-/bottts-9.4.2.tgz",
+      "integrity": "sha512-tsx+dII7EFUCVA8URj66G1GqORCCVduCAx4dY2prEY2IeFianVpkntXuFsWZ9BBGx1NZFndvDith5oTwKMQPbQ==",
+      "license": "See LICENSE file",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/bottts-neutral": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/bottts-neutral/-/bottts-neutral-9.4.2.tgz",
+      "integrity": "sha512-kFNwWt6j+gzZ5n5Pz7WVwePubREAQOF8ZwWA9ztwVYDVMLnOChWbAofy5FED4j5md2MXFH2EgLCFCMr5K2BmIA==",
+      "license": "See LICENSE file",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/collection": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/collection/-/collection-9.4.2.tgz",
+      "integrity": "sha512-KArubv7if8H7j9sIfpDK2hJJqrdNVR5zMPAMOSpIU2JPyXx8TC9o5wsmXb8il5wOHgaS9Q/cla7jUNIiDD7Gsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dicebear/adventurer": "9.4.2",
+        "@dicebear/adventurer-neutral": "9.4.2",
+        "@dicebear/avataaars": "9.4.2",
+        "@dicebear/avataaars-neutral": "9.4.2",
+        "@dicebear/big-ears": "9.4.2",
+        "@dicebear/big-ears-neutral": "9.4.2",
+        "@dicebear/big-smile": "9.4.2",
+        "@dicebear/bottts": "9.4.2",
+        "@dicebear/bottts-neutral": "9.4.2",
+        "@dicebear/croodles": "9.4.2",
+        "@dicebear/croodles-neutral": "9.4.2",
+        "@dicebear/dylan": "9.4.2",
+        "@dicebear/fun-emoji": "9.4.2",
+        "@dicebear/glass": "9.4.2",
+        "@dicebear/icons": "9.4.2",
+        "@dicebear/identicon": "9.4.2",
+        "@dicebear/initials": "9.4.2",
+        "@dicebear/lorelei": "9.4.2",
+        "@dicebear/lorelei-neutral": "9.4.2",
+        "@dicebear/micah": "9.4.2",
+        "@dicebear/miniavs": "9.4.2",
+        "@dicebear/notionists": "9.4.2",
+        "@dicebear/notionists-neutral": "9.4.2",
+        "@dicebear/open-peeps": "9.4.2",
+        "@dicebear/personas": "9.4.2",
+        "@dicebear/pixel-art": "9.4.2",
+        "@dicebear/pixel-art-neutral": "9.4.2",
+        "@dicebear/rings": "9.4.2",
+        "@dicebear/shapes": "9.4.2",
+        "@dicebear/thumbs": "9.4.2",
+        "@dicebear/toon-head": "9.4.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/core": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/core/-/core-9.4.2.tgz",
+      "integrity": "sha512-MF0042+Z3s8PGZKZLySfhft28bUa3B1iq0e5NSjCvY8gfMi5aIH/iRJGRJa1N9Jz1BNkxYb4yvJ/N9KO8Z6Y+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@dicebear/croodles": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/croodles/-/croodles-9.4.2.tgz",
+      "integrity": "sha512-6VoO0JviIf7dKKMBTL/SMXxWhnXHaZuzufX90G0nXxS77ELG1YkGNMaZzawizN4C09Gbya2gJkozqrWiJN/aGw==",
+      "license": "(MIT AND CC-BY-4.0)",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/croodles-neutral": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/croodles-neutral/-/croodles-neutral-9.4.2.tgz",
+      "integrity": "sha512-oG5IeUdtiYshQ89gkAVcl5w3xAEi5UZX2fTzIyelpBPCG176l7VuuFzlxi2umnB3E6LVHYy06DXvUo/p+rXB2Q==",
+      "license": "(MIT AND CC-BY-4.0)",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/dylan": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/dylan/-/dylan-9.4.2.tgz",
+      "integrity": "sha512-1vQvRu9x9DrwFxhFaIU2rf0EUL04yDTbAt7fHyAjM0mEsKzTD4mRNf95tCRuavCoW6W48u7A/OY6jyIub6kxLQ==",
+      "license": "(MIT AND CC-BY-4.0)",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/fun-emoji": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/fun-emoji/-/fun-emoji-9.4.2.tgz",
+      "integrity": "sha512-kqB6LPkdYCdEU/mwbyz34xLzoNUKL6ARcoo3fr5ASq9D6ZE07qIKybC3xv5+CPz7VmspJ1Q3c/VVWVMDRP7Twg==",
+      "license": "(MIT AND CC-BY-4.0)",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/glass": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/glass/-/glass-9.4.2.tgz",
+      "integrity": "sha512-z5qUogHQ1b6UJ2zCqT848mU2U9DKbVDhiX6GPDjD7tYLisCCJVisH9p6WyNdHvflUd4SHkA6gRqVJIh2v2HnTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/icons": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/icons/-/icons-9.4.2.tgz",
+      "integrity": "sha512-QSMMz0NA03ypSGhXC8HQX8FSj8lYT+/5yqH+/N03OH2IjL0q7wwGZ7nqsrtlRp76O5WqMTwGfSbTUUYPjFr+Xw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/identicon": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/identicon/-/identicon-9.4.2.tgz",
+      "integrity": "sha512-JVDSmZsv11mSWqwAktK5x9Bslht2xY3TFUn8xzu6slAYe1Z7hEXZ76eb+UJ6F4qEzdwZ7xPWzAS6Nb0Y3A0pww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/initials": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/initials/-/initials-9.4.2.tgz",
+      "integrity": "sha512-yePuIUasmwtl9IrtB6rEzE/zb5fImKP/neW0CdcTC2MwLgMuP1GLHEGRgg1zI8exIh+PMv1YdLGyyUuRTE2Qpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/lorelei": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/lorelei/-/lorelei-9.4.2.tgz",
+      "integrity": "sha512-YMv6vnriW6VLFDsreKuOnUFFno6SRe7+7X7R7zPY0rZ+MaHX9V3jcioIG+1PSjIHEDfOLUHpr5vd1JBWv8y7UA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/lorelei-neutral": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/lorelei-neutral/-/lorelei-neutral-9.4.2.tgz",
+      "integrity": "sha512-yspanTthA5vh6iCdeLzn6xZ4yYMYRcfcxblcgSvHTF1ut0bjAXtw5SXzZ6aJTrJWiHkzYOQuTOR6GVYiW80Q7w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/micah": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/micah/-/micah-9.4.2.tgz",
+      "integrity": "sha512-e4D3W/OlChSsLo7Llwsy0J18vk0azJqF/uFoY+EKACCNHBc1HGNsqVvu2CTf+OWOA8wTyAK6UkjBN5p01r7D+g==",
+      "license": "(MIT AND CC-BY-4.0)",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/miniavs": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/miniavs/-/miniavs-9.4.2.tgz",
+      "integrity": "sha512-wLwyFNNUnDRd3BbhSBhXR0XEpX8sG0/xDA5M/OkDoapLqZnnI48YLUSDd2N5QTAVMmcSEuZOYxkcnj7WW79vlg==",
+      "license": "(MIT AND CC-BY-4.0)",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/notionists": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/notionists/-/notionists-9.4.2.tgz",
+      "integrity": "sha512-ZCySq+nxcD/x4xyYgytcj2N9uY3gxrL+qpnmOdp2BdA221KacVrxlsUPpIgEMqxS2rMmBQXfxg129Pzn4ycIpA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/notionists-neutral": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/notionists-neutral/-/notionists-neutral-9.4.2.tgz",
+      "integrity": "sha512-AyD9kEfVxQUwDGf4Op059gVmYIOAkTKg3dtE9h9mEKP7zl/kMy5B67BFFOo7sB0mXCjzAegZ6ekGU02E8+hIHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/open-peeps": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/open-peeps/-/open-peeps-9.4.2.tgz",
+      "integrity": "sha512-i01tLgtp2g937T81sVeAOVlqsCtiTck/Kw20g7hN80+7xrXjOUepz2HPLy3HeiMjwjMGRy5o54kSd0/8Ht4Dqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/personas": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/personas/-/personas-9.4.2.tgz",
+      "integrity": "sha512-NJlkvI5F5gugt6t2+7QrYNTwQC7+4IQZS3vG0dYk2BncxOHax0BuLovdSdiAesTL4ZkytFYIydWmKmV2/xcUwg==",
+      "license": "(MIT AND CC-BY-4.0)",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/pixel-art": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/pixel-art/-/pixel-art-9.4.2.tgz",
+      "integrity": "sha512-peHf7oKICDgBZ8dUyj+txPnS7VZEWgvKE+xW4mNQqBt6dYZIjmva2shOVHn0b1JU+FDxMx3uIkWVixKdUq4WGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/pixel-art-neutral": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/pixel-art-neutral/-/pixel-art-neutral-9.4.2.tgz",
+      "integrity": "sha512-9e9Lz554uQvWaXV2P17ss+hPa6rTyuAKBtB8zk8ECjHiZzIl61N/KcTVLZ4dILVZwj7gYriaLo16QEqvL2GJCg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/rings": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/rings/-/rings-9.4.2.tgz",
+      "integrity": "sha512-Pc3ymWrRDQPJFNrbbLt7RJrzGvUuuxUiDkrfLhoVE+B6mZWEL1PC78DPbS1yUWYLErJOpJuM2GSwXmTbVjWf+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/shapes": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/shapes/-/shapes-9.4.2.tgz",
+      "integrity": "sha512-AFL6jAaiLztvcqyq+ds+lWZu6Vbp3PlGWhJeJRm842jxtiluJpl6r4f6nUXP2fdMz7MNpDzXfLooQK9E04NbUQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/thumbs": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/thumbs/-/thumbs-9.4.2.tgz",
+      "integrity": "sha512-ccWvDBqbkWS5uzHbsg5L6uML6vBfX7jT3J3jHCQksvz8haHItxTK02w+6e1UavZUsvza4lG5X/XY3eji3siJ4Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
+      }
+    },
+    "node_modules/@dicebear/toon-head": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/@dicebear/toon-head/-/toon-head-9.4.2.tgz",
+      "integrity": "sha512-lwFeSXyAnaKnCfMt9TiJwnD1cXQUGkey/0h6i/+4TVHVMCz5/Ri5u1ynovPNHy1SnBf858QwoXHkxilGLwQX/g==",
+      "license": "(MIT AND CC-BY-4.0)",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@dicebear/core": "^9.0.0"
       }
     },
     "node_modules/@electron/asar": {
@@ -2638,6 +3069,12 @@
         "@types/tough-cookie": "*",
         "parse5": "^7.0.0"
       }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
     },
     "node_modules/@types/keyv": {
       "version": "3.1.4",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,8 @@
     ]
   },
   "dependencies": {
+    "@dicebear/collection": "^9.4.2",
+    "@dicebear/core": "^9.4.2",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "node-pty": "^1.1.0",

--- a/src/main/ipc-handlers.ts
+++ b/src/main/ipc-handlers.ts
@@ -8,6 +8,7 @@ import { IPC } from '../renderer/types/ipc'
 import type { CreateSessionOptions, Keybindings, ThemeSettings } from '../renderer/types/ipc'
 import { runGitCommand } from './git-service'
 import { CompanionPtyManager } from './companion-pty-manager'
+import { parseSpriteSpeech } from './sprite-parser'
 
 export async function readKeybindingsFromDisk(baseDir = os.homedir()): Promise<Keybindings | null> {
   const p = path.join(baseDir, '.overseer', 'keybindings.json')
@@ -57,6 +58,16 @@ export function registerIpcHandlers(
 ): void {
   service.onData((sessionId, data) => {
     getWindow()?.webContents.send(`pty:data:${sessionId}`, data)
+    try {
+      const events = parseSpriteSpeech(data)
+      for (const ev of events) {
+        if (ev.type === 'speech') {
+          getWindow()?.webContents.send(IPC.SPRITE_SPEECH, { sessionId, text: ev.text })
+        }
+      }
+    } catch (err) {
+      console.error('[Sprite] Speech parse error:', err)
+    }
   })
 
   service.onError((sessionId, err) => {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -94,4 +94,10 @@ contextBridge.exposeInMainWorld('overseer', {
     ipcRenderer.on('companion:exit', handler)
     return () => ipcRenderer.removeListener('companion:exit', handler)
   },
+
+  onSpriteSpeech: (callback: (payload: { sessionId: string; text: string }) => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, payload: { sessionId: string; text: string }) => callback(payload)
+    ipcRenderer.on(IPC.SPRITE_SPEECH, handler)
+    return () => ipcRenderer.removeListener(IPC.SPRITE_SPEECH, handler)
+  },
 })

--- a/src/main/session-service/index.ts
+++ b/src/main/session-service/index.ts
@@ -36,6 +36,9 @@ export class SessionService {
   create(options: CreateSessionOptions): Session {
     const id = randomUUID()
     const envVars = readAgentEnvVars(options.agentType)
+    if (options.persona) {
+      envVars['OVERSEER_SPRITE_PERSONA'] = options.persona
+    }
     const session: Session = {
       id,
       name: options.name,
@@ -43,6 +46,7 @@ export class SessionService {
       cwd: options.cwd || os.homedir(),
       envVars,
       scrollbackPath: path.join(os.homedir(), '.overseer', 'sessions', `${id}.log`),
+      spriteId: options.spriteId ?? null,
     }
     this.registry.add(session)
     this.spawnPty(session)
@@ -82,5 +86,19 @@ export class SessionService {
       (data) => { this.onDataCallback?.(session.id, data) },
       (err) => { this.onErrorCallback?.(session.id, err) }
     )
+    const persona = session.envVars['OVERSEER_SPRITE_PERSONA']
+    if (persona && session.agentType === 'claude') {
+      const escaped = persona
+        .replace(/\\/g, '\\\\')
+        .replace(/"/g, '\\"')
+        .replace(/\n/g, ' ')
+      setTimeout(() => {
+        try {
+          this.ptyManager.write(session.id, `claude --system-prompt "${escaped}"\r`)
+        } catch (err) {
+          console.error(`[Sprite] Persona injection failed for session ${session.id}:`, err)
+        }
+      }, 300)
+    }
   }
 }

--- a/src/main/sprite-parser.ts
+++ b/src/main/sprite-parser.ts
@@ -1,0 +1,17 @@
+export interface ParsedSpriteEvent {
+  type: 'speech'
+  text: string
+}
+
+const SPEAK_REGEX = /<speak>([\s\S]+?)<\/speak>/g
+
+export function parseSpriteSpeech(chunk: string): ParsedSpriteEvent[] {
+  const events: ParsedSpriteEvent[] = []
+  let match: RegExpExecArray | null
+  SPEAK_REGEX.lastIndex = 0
+  while ((match = SPEAK_REGEX.exec(chunk)) !== null) {
+    const text = match[1].trim()
+    if (text) events.push({ type: 'speech', text })
+  }
+  return events
+}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2,7 +2,8 @@ import React, { useEffect, useState } from 'react'
 import { useSessionStore } from './store/sessions'
 import { TabBar } from './components/TabBar'
 import { TerminalPane } from './components/TerminalPane'
-import { GitPanel } from './components/GitPanel'
+import { RightSidebar } from './components/RightSidebar'
+import { SpriteStudio } from './components/SpriteStudio'
 import { NewSessionDialog } from './components/NewSessionDialog'
 import { SessionDrawer } from './components/SessionDrawer'
 import { SettingsModal } from './components/SettingsModal'
@@ -21,6 +22,9 @@ export default function App() {
   const [showSettings,       setShowSettings]        = useState(false)
   const [showShortcutsModal, setShowShortcutsModal] = useState(false)
   const [confirmKillId,      setConfirmKillId]      = useState<string | null>(null)
+  const [showSpriteStudio,   setShowSpriteStudio]   = useState(false)
+  const [spriteStudioEditId, setSpriteStudioEditId] = useState<string | null>(null)
+  const [spritePanelVisible, setSpritePanelVisible] = useState(true)
 
   useEffect(() => { load(); loadThemeSettings() }, [])
 
@@ -95,6 +99,8 @@ export default function App() {
     onSplitSwap,
     onSplitSwapSecondary,
     onSplitToggleDirection,
+    onToggleSpritePanel: () => setSpritePanelVisible(v => !v),
+    onOpenSpriteStudio:  () => { setSpriteStudioEditId(null); setShowSpriteStudio(true) },
   })
 
   const handleCreate = async (options: CreateSessionOptions) => {
@@ -147,7 +153,11 @@ export default function App() {
           onOuterRatio={onOuterRatio}
           onInnerRatio={onInnerRatio}
         />
-        {activeSession && <GitPanel cwd={activeSession.cwd} />}
+        <RightSidebar
+          activeSession={activeSession}
+          spritePanelVisible={spritePanelVisible}
+          onOpenStudio={() => { setSpriteStudioEditId(null); setShowSpriteStudio(true) }}
+        />
       </div>
 
       {showNewDialog && (
@@ -179,6 +189,13 @@ export default function App() {
         <KeyboardShortcutsModal
           keybindings={keybindings}
           onClose={() => setShowShortcutsModal(false)}
+        />
+      )}
+
+      {showSpriteStudio && (
+        <SpriteStudio
+          onClose={() => setShowSpriteStudio(false)}
+          editingId={spriteStudioEditId}
         />
       )}
     </div>

--- a/src/renderer/components/GitPanel.tsx
+++ b/src/renderer/components/GitPanel.tsx
@@ -33,8 +33,8 @@ export function GitPanel({ cwd }: Props) {
   }
 
   const panelStyle: React.CSSProperties = {
-    width: '260px', background: 'var(--bg-sidebar)', display: 'flex', flexDirection: 'column',
-    padding: '12px', gap: '8px', borderLeft: '1px solid var(--border)',
+    flex: 1, background: 'var(--bg-sidebar)', display: 'flex', flexDirection: 'column',
+    padding: '12px', gap: '8px',
   }
   const btnStyle: React.CSSProperties = {
     background: 'var(--accent)', color: '#fff', border: 'none', borderRadius: '4px',

--- a/src/renderer/components/KeyboardShortcutsModal.tsx
+++ b/src/renderer/components/KeyboardShortcutsModal.tsx
@@ -31,6 +31,8 @@ const ACTION_LABELS: Record<string, string> = {
   splitSwap:            'Swap Main / Secondary Columns',
   splitSwapSecondary:   'Swap Companion Panes (3-way)',
   splitToggleDirection: 'Toggle Split Direction',
+  toggleSpritePanel:    'Toggle Sprite Panel',
+  openSpriteStudio:     'Open Sprite Studio',
 }
 
 const GROUPS: { title: string, actions: KeybindingAction[] }[] = [
@@ -53,6 +55,10 @@ const GROUPS: { title: string, actions: KeybindingAction[] }[] = [
   {
     title: 'GENERAL',
     actions: ['openDrawer', 'openSettings', 'openShortcuts']
+  },
+  {
+    title: 'SPRITE',
+    actions: ['toggleSpritePanel', 'openSpriteStudio']
   }
 ]
 

--- a/src/renderer/components/NewSessionDialog.tsx
+++ b/src/renderer/components/NewSessionDialog.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import type { CreateSessionOptions, Session } from '../types/ipc'
+import { useSpritesStore } from '../store/sprites'
 
 interface Props {
   onCreate: (options: CreateSessionOptions) => void
@@ -11,6 +12,8 @@ export function NewSessionDialog({ onCreate, onCancel }: Props) {
   const [agentType, setAgentType] = useState<Session['agentType']>('shell')
   const [cwd, setCwd] = useState('')
   const [cwdValid, setCwdValid] = useState<boolean | null>(null)
+  const [selectedSpriteId, setSelectedSpriteId] = useState<string>('')
+  const sprites = useSpritesStore(s => s.sprites)
 
   useEffect(() => {
     setCwdValid(null)
@@ -29,7 +32,14 @@ export function NewSessionDialog({ onCreate, onCancel }: Props) {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
-    onCreate({ name, agentType, cwd })
+    const sprite = sprites.find(s => s.id === selectedSpriteId)
+    onCreate({
+      name,
+      agentType,
+      cwd,
+      spriteId: sprite?.id ?? null,
+      persona: sprite?.persona,
+    })
   }
 
   const overlayStyle: React.CSSProperties = {
@@ -72,6 +82,15 @@ export function NewSessionDialog({ onCreate, onCancel }: Props) {
             <button type="button" onClick={handleBrowse} style={{ ...inputStyle, cursor: 'pointer', whiteSpace: 'nowrap' }}>Browse</button>
           </div>
           {cwdValid === false && <span style={{ color: '#e05252', fontSize: '12px' }}>Directory not found</span>}
+        </label>
+        <label style={labelStyle} htmlFor="sprite-select">
+          Sprite <span style={{ color: 'var(--text-muted)', fontWeight: 'normal' }}>(optional)</span>
+          <select id="sprite-select" aria-label="Sprite" style={inputStyle} value={selectedSpriteId} onChange={e => setSelectedSpriteId(e.target.value)}>
+            <option value="">None</option>
+            {sprites.map(s => (
+              <option key={s.id} value={s.id}>{s.name}</option>
+            ))}
+          </select>
         </label>
         <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
           <button type="button" onClick={onCancel} style={{ ...inputStyle, cursor: 'pointer' }}>Cancel</button>

--- a/src/renderer/components/RightSidebar.tsx
+++ b/src/renderer/components/RightSidebar.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { GitPanel } from './GitPanel'
+import { SpritePanel } from './SpritePanel'
+import type { Session } from '../types/ipc'
+
+interface Props {
+  activeSession: Session | undefined
+  spritePanelVisible: boolean
+  onOpenStudio: () => void
+}
+
+export function RightSidebar({ activeSession, spritePanelVisible, onOpenStudio }: Props) {
+  if (!activeSession) return null
+
+  return (
+    <div style={{
+      width: '260px',
+      background: 'var(--bg-sidebar)',
+      borderLeft: '1px solid var(--border)',
+      display: 'flex',
+      flexDirection: 'column',
+      overflow: 'hidden',
+    }}>
+      <GitPanel cwd={activeSession.cwd} />
+      <SpritePanel
+        sessionId={activeSession.id}
+        spriteId={activeSession.spriteId ?? null}
+        animationState="idle"
+        visible={spritePanelVisible}
+        onOpenStudio={onOpenStudio}
+      />
+    </div>
+  )
+}

--- a/src/renderer/components/SpritePanel.tsx
+++ b/src/renderer/components/SpritePanel.tsx
@@ -1,0 +1,98 @@
+import React, { useEffect, useState, useRef } from 'react'
+import { createAvatar } from '@dicebear/core'
+import { bottts } from '@dicebear/collection'
+import { useSpritesStore } from '../store/sprites'
+
+interface Props {
+  sessionId: string | null
+  spriteId: string | null
+  animationState: 'idle' | 'talking' | 'thinking'  // no-op in MVP; prop exists for future extension
+  visible: boolean
+  onOpenStudio: () => void
+}
+
+export function SpritePanel({ sessionId, spriteId, animationState: _animationState, visible, onOpenStudio }: Props) {
+  const sprites = useSpritesStore(s => s.sprites)
+  const sprite = spriteId ? (sprites.find(s => s.id === spriteId) ?? null) : null
+  const [speechText, setSpeechText] = useState('')
+  const clearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    if (!sessionId) return
+    const unsub = window.overseer.onSpriteSpeech(({ sessionId: sid, text }) => {
+      if (sid !== sessionId) return
+      setSpeechText(text)
+      if (clearTimerRef.current) clearTimeout(clearTimerRef.current)
+      clearTimerRef.current = setTimeout(() => setSpeechText(''), 8000)
+    })
+    return () => {
+      unsub()
+      if (clearTimerRef.current) clearTimeout(clearTimerRef.current)
+    }
+  }, [sessionId])
+
+  if (!visible) return null
+
+  let avatarSvg = ''
+  if (sprite) {
+    try {
+      avatarSvg = createAvatar(bottts, { seed: sprite.seed }).toString()
+    } catch (err) {
+      console.error(`[Sprite] Avatar render failed for sprite ${sprite.id}:`, err)
+    }
+  }
+
+  const containerStyle: React.CSSProperties = {
+    borderTop: '1px solid var(--border)',
+    padding: '12px',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: '8px',
+    minHeight: '160px',
+  }
+  const labelStyle: React.CSSProperties = {
+    color: 'var(--text-muted)', fontSize: '11px', textTransform: 'uppercase', letterSpacing: '0.08em', alignSelf: 'flex-start',
+  }
+
+  if (!sprite) {
+    return (
+      <div style={containerStyle}>
+        <div style={labelStyle}>Sprite</div>
+        <div style={{ color: 'var(--text-muted)', fontSize: '12px', textAlign: 'center' }}>No Sprite assigned</div>
+        <button
+          onClick={onOpenStudio}
+          style={{ background: 'var(--accent)', color: '#fff', border: 'none', borderRadius: '4px', padding: '6px 12px', cursor: 'pointer', fontSize: '12px' }}
+        >
+          Open Studio
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div style={containerStyle}>
+      <div style={labelStyle}>Sprite — {sprite.name}</div>
+      {speechText && (
+        <div style={{
+          background: 'var(--bg-main)',
+          border: '1px solid var(--border)',
+          borderRadius: '8px',
+          padding: '8px 10px',
+          fontSize: '12px',
+          color: 'var(--text-main)',
+          maxWidth: '220px',
+          textAlign: 'center',
+        }}>
+          {speechText}
+        </div>
+      )}
+      {avatarSvg && (
+        <div
+          style={{ width: '80px', height: '80px' }}
+          dangerouslySetInnerHTML={{ __html: avatarSvg }}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/SpriteStudio.tsx
+++ b/src/renderer/components/SpriteStudio.tsx
@@ -1,0 +1,126 @@
+import React, { useState } from 'react'
+import { createAvatar } from '@dicebear/core'
+import { bottts } from '@dicebear/collection'
+import { useSpritesStore } from '../store/sprites'
+
+interface Props {
+  onClose: () => void
+  editingId?: string | null
+}
+
+export function SpriteStudio({ onClose, editingId }: Props) {
+  const { sprites, createSprite, updateSprite, deleteSprite } = useSpritesStore()
+  const editing = editingId ? (sprites.find(s => s.id === editingId) ?? null) : null
+
+  const [name, setName] = useState(editing?.name ?? '')
+  const [seed, setSeed] = useState(editing?.seed ?? '')
+  const [persona, setPersona] = useState(editing?.persona ?? '')
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const deleteTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  let previewSvg = ''
+  if (seed) {
+    try {
+      previewSvg = createAvatar(bottts, { seed }).toString()
+    } catch (err) {
+      console.error('[Sprite] Avatar preview render failed:', err)
+    }
+  }
+
+  const handleSave = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!name.trim()) return
+    if (editing) {
+      updateSprite(editing.id, { name: name.trim(), seed, persona })
+    } else {
+      createSprite({ name: name.trim(), style: 'bottts', seed, persona })
+    }
+    onClose()
+  }
+
+  const handleDelete = () => {
+    if (!editing) return
+    if (confirmDelete) {
+      if (deleteTimerRef.current) clearTimeout(deleteTimerRef.current)
+      deleteSprite(editing.id)
+      onClose()
+    } else {
+      setConfirmDelete(true)
+      deleteTimerRef.current = setTimeout(() => setConfirmDelete(false), 2000)
+    }
+  }
+
+  const overlayStyle: React.CSSProperties = {
+    position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.6)',
+    display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 100,
+  }
+  const dialogStyle: React.CSSProperties = {
+    background: 'var(--bg-header)', padding: '24px', borderRadius: '8px',
+    display: 'flex', flexDirection: 'column', gap: '16px', minWidth: '420px', maxWidth: '560px', width: '100%',
+  }
+  const inputStyle: React.CSSProperties = {
+    background: 'var(--bg-main)', color: 'var(--text-main)', border: '1px solid var(--border)',
+    borderRadius: '4px', padding: '6px 8px', width: '100%', boxSizing: 'border-box',
+  }
+  const labelStyle: React.CSSProperties = {
+    color: 'var(--text-main)', display: 'flex', flexDirection: 'column', gap: '4px',
+  }
+
+  return (
+    <div style={overlayStyle}>
+      <form style={dialogStyle} onSubmit={handleSave}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <h2 style={{ color: 'var(--text-main)', margin: 0 }}>{editing ? 'Edit Sprite' : 'New Sprite'}</h2>
+          <button type="button" onClick={onClose} style={{ background: 'transparent', border: 'none', color: 'var(--text-muted)', cursor: 'pointer', fontSize: '18px' }}>✕</button>
+        </div>
+
+        <label style={labelStyle} htmlFor="sprite-name">
+          Name
+          <input id="sprite-name" aria-label="Name" style={inputStyle} value={name} onChange={e => setName(e.target.value)} required autoFocus />
+        </label>
+
+        <label style={labelStyle} htmlFor="sprite-seed">
+          Avatar Seed
+          <input id="sprite-seed" aria-label="Avatar Seed" style={inputStyle} value={seed} onChange={e => setSeed(e.target.value)} placeholder="Any text — changes the avatar shape" />
+        </label>
+
+        {previewSvg && (
+          <div style={{ display: 'flex', justifyContent: 'center' }}>
+            <div style={{ width: '80px', height: '80px' }} dangerouslySetInnerHTML={{ __html: previewSvg }} />
+          </div>
+        )}
+
+        <label style={labelStyle} htmlFor="sprite-persona">
+          Persona
+          <textarea
+            id="sprite-persona"
+            aria-label="Persona"
+            style={{ ...inputStyle, minHeight: '80px', resize: 'vertical', fontFamily: 'inherit' }}
+            value={persona}
+            onChange={e => setPersona(e.target.value)}
+            placeholder="Describe the character personality..."
+          />
+        </label>
+
+        <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end', flexWrap: 'wrap' }}>
+          {editing && (
+            <button
+              type="button"
+              onClick={handleDelete}
+              style={{
+                background: confirmDelete ? '#c0392b' : 'transparent',
+                color: confirmDelete ? '#fff' : '#e05252',
+                border: '1px solid #e05252',
+                borderRadius: '4px', padding: '6px 12px', cursor: 'pointer',
+              }}
+            >
+              {confirmDelete ? 'Confirm Delete' : 'Delete'}
+            </button>
+          )}
+          <button type="button" onClick={onClose} style={{ background: 'transparent', color: 'var(--text-main)', border: '1px solid var(--border)', borderRadius: '4px', padding: '6px 12px', cursor: 'pointer' }}>Cancel</button>
+          <button type="submit" style={{ background: 'var(--accent)', color: '#fff', border: 'none', borderRadius: '4px', padding: '6px 12px', cursor: 'pointer' }}>Save</button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -18,6 +18,8 @@ export interface ShortcutHandlers {
   onSplitSwap:            () => void
   onSplitSwapSecondary:   () => void
   onSplitToggleDirection: () => void
+  onToggleSpritePanel:   () => void
+  onOpenSpriteStudio:    () => void
 }
 
 export interface KeyboardShortcutsAPI {
@@ -56,6 +58,8 @@ export function useKeyboardShortcuts(handlers: ShortcutHandlers): KeyboardShortc
       if (action === 'splitSwap')            { h.onSplitSwap();            return }
       if (action === 'splitSwapSecondary')   { h.onSplitSwapSecondary();   return }
       if (action === 'splitToggleDirection') { h.onSplitToggleDirection(); return }
+      if (action === 'toggleSpritePanel')   { h.onToggleSpritePanel();   return }
+      if (action === 'openSpriteStudio')    { h.onOpenSpriteStudio();    return }
       const idxMatch = action.match(/^sessionByIndex(\d)$/)
       if (idxMatch) h.onSessionByIndex(parseInt(idxMatch[1], 10))
     }

--- a/src/renderer/store/sprites.ts
+++ b/src/renderer/store/sprites.ts
@@ -1,0 +1,39 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+export interface Sprite {
+  id: string
+  name: string
+  style: string  // DiceBear collection key — MVP: always 'bottts'
+  seed: string
+  persona: string
+}
+
+interface SpritesState {
+  sprites: Sprite[]
+  createSprite: (s: Omit<Sprite, 'id'>) => Sprite
+  updateSprite: (id: string, patch: Partial<Omit<Sprite, 'id'>>) => void
+  deleteSprite: (id: string) => void
+}
+
+export const useSpritesStore = create<SpritesState>()(
+  persist(
+    (set) => ({
+      sprites: [],
+      createSprite: (s) => {
+        const sprite: Sprite = { ...s, id: crypto.randomUUID() }
+        set(state => ({ sprites: [...state.sprites, sprite] }))
+        return sprite
+      },
+      updateSprite: (id, patch) => {
+        set(state => ({
+          sprites: state.sprites.map(s => s.id === id ? { ...s, ...patch } : s),
+        }))
+      },
+      deleteSprite: (id) => {
+        set(state => ({ sprites: state.sprites.filter(s => s.id !== id) }))
+      },
+    }),
+    { name: 'overseer-sprites' }
+  )
+)

--- a/src/renderer/types/electron.d.ts
+++ b/src/renderer/types/electron.d.ts
@@ -29,6 +29,7 @@ declare global {
       resizeCompanion: (companionId: string, cols: number, rows: number) => Promise<void>
       onCompanionData: (callback: (id: string, data: string) => void) => () => void
       onCompanionExit: (callback: (id: string) => void) => () => void
+      onSpriteSpeech: (callback: (payload: { sessionId: string; text: string }) => void) => () => void
     }
   }
 }

--- a/src/renderer/types/ipc.ts
+++ b/src/renderer/types/ipc.ts
@@ -5,12 +5,15 @@ export interface Session {
   cwd: string
   envVars: Record<string, string>
   scrollbackPath: string
+  spriteId: string | null
 }
 
 export interface CreateSessionOptions {
   name: string
   agentType: Session['agentType']
   cwd?: string
+  spriteId?: string | null
+  persona?: string
 }
 
 export interface GitCommandResult {
@@ -72,6 +75,8 @@ export type KeybindingAction =
   | 'splitSwap'
   | 'splitSwapSecondary'
   | 'splitToggleDirection'
+  | 'toggleSpritePanel'
+  | 'openSpriteStudio'
 
 export type Keybindings = Record<KeybindingAction, Keybinding>
 
@@ -99,6 +104,8 @@ export const DEFAULT_KEYBINDINGS: Keybindings = {
   splitSwap:            { code: 'KeyM',         ctrl: true,  shift: true,  alt: false },
   splitSwapSecondary:   { code: 'KeyJ',         ctrl: true,  shift: true,  alt: false },
   splitToggleDirection: { code: 'Backquote',    ctrl: true,  shift: true,  alt: false },
+  toggleSpritePanel:    { code: 'KeyS',         ctrl: true,  shift: true,  alt: false },
+  openSpriteStudio:     { code: 'KeyP',         ctrl: true,  shift: true,  alt: false },
 }
 
 const CODE_LABELS: Record<string, string> = {
@@ -161,4 +168,5 @@ export const IPC = {
   COMPANION_KILL:    'companion:kill',
   COMPANION_INPUT:   'companion:input',
   COMPANION_RESIZE:  'companion:resize',
+  SPRITE_SPEECH:     'sprite:speech',
 } as const

--- a/tests/main/pty-manager.test.ts
+++ b/tests/main/pty-manager.test.ts
@@ -17,6 +17,7 @@ function makeSession(id: string): Session {
     cwd: os.tmpdir(),
     envVars: {},
     scrollbackPath: path.join(tmpDir, `${id}.log`),
+    spriteId: null,
   }
 }
 

--- a/tests/main/registry.test.ts
+++ b/tests/main/registry.test.ts
@@ -17,6 +17,7 @@ function makeSession(overrides: Partial<Session> = {}): Session {
     cwd: '/tmp',
     envVars: {},
     scrollbackPath: '/tmp/test-id.log',
+    spriteId: null,
     ...overrides,
   }
 }

--- a/tests/main/sprite-parser.test.ts
+++ b/tests/main/sprite-parser.test.ts
@@ -1,0 +1,35 @@
+import { parseSpriteSpeech } from '../../src/main/sprite-parser'
+
+test('returns empty array for chunk with no speak tags', () => {
+  expect(parseSpriteSpeech('hello world')).toEqual([])
+})
+
+test('returns empty array for empty string', () => {
+  expect(parseSpriteSpeech('')).toEqual([])
+})
+
+test('extracts a single speak tag', () => {
+  expect(parseSpriteSpeech('<speak>hey there</speak>')).toEqual([
+    { type: 'speech', text: 'hey there' },
+  ])
+})
+
+test('extracts multiple speak tags from one chunk', () => {
+  expect(parseSpriteSpeech('foo <speak>one</speak> bar <speak>two</speak> baz')).toEqual([
+    { type: 'speech', text: 'one' },
+    { type: 'speech', text: 'two' },
+  ])
+})
+
+test('ignores unclosed speak tags', () => {
+  expect(parseSpriteSpeech('<speak>unclosed')).toEqual([])
+})
+
+test('ignores empty speak tags', () => {
+  expect(parseSpriteSpeech('<speak></speak>')).toEqual([])
+})
+
+test('handles speak tag mixed with other output', () => {
+  const chunk = '[32msome ansi[0m <speak>hello sailor</speak> more text'
+  expect(parseSpriteSpeech(chunk)).toEqual([{ type: 'speech', text: 'hello sailor' }])
+})

--- a/tests/renderer/App-shortcuts-toggle.test.tsx
+++ b/tests/renderer/App-shortcuts-toggle.test.tsx
@@ -3,12 +3,15 @@ import { render, screen, act } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import App from '../../src/renderer/App'
 
-// Mock components that use xterm
+// Mock components that use xterm or DiceBear
 jest.mock('../../src/renderer/components/TerminalPane', () => ({
   TerminalPane: () => <div data-testid="terminal-pane" />
 }))
-jest.mock('../../src/renderer/components/GitPanel', () => ({
-  GitPanel: () => <div data-testid="git-panel" />
+jest.mock('../../src/renderer/components/RightSidebar', () => ({
+  RightSidebar: () => <div data-testid="right-sidebar" />
+}))
+jest.mock('../../src/renderer/components/SpriteStudio', () => ({
+  SpriteStudio: () => <div data-testid="sprite-studio" />
 }))
 
 // Mock the window.overseer API
@@ -27,6 +30,7 @@ beforeEach(() => {
     onCompanionData: jest.fn().mockReturnValue(() => {}),
     onCompanionError: jest.fn().mockReturnValue(() => {}),
     onCompanionExit: jest.fn().mockReturnValue(() => {}),
+    onSpriteSpeech: jest.fn().mockReturnValue(() => {}),
     spawnCompanion: jest.fn().mockResolvedValue({ id: 'c1' }),
     killCompanion: jest.fn().mockResolvedValue(undefined),
     killSession: jest.fn().mockResolvedValue(undefined),
@@ -70,7 +74,7 @@ test('Slash key closes KeyboardShortcutsModal when open', async () => {
 })
 
 test('Ctrl+Shift+W requires two presses to kill session', async () => {
-  const session = { id: 's1', name: 'Session 1', agentType: 'shell', cwd: '/', envVars: {}, scrollbackPath: '' }
+  const session = { id: 's1', name: 'Session 1', agentType: 'shell', cwd: '/', envVars: {}, scrollbackPath: '', spriteId: null }
   ;(window as any).overseer.listSessions.mockResolvedValue([session])
 
   render(<App />)

--- a/tests/renderer/NewSessionDialog.test.tsx
+++ b/tests/renderer/NewSessionDialog.test.tsx
@@ -37,6 +37,8 @@ test('calls onCreate with form values on submit', async () => {
     name: 'my-session',
     agentType: 'claude',
     cwd: '/home/user/project',
+    spriteId: null,
+    persona: undefined,
   })
 })
 
@@ -111,5 +113,7 @@ test('allows Create with empty cwd', () => {
     name: 'my-session',
     agentType: 'shell',
     cwd: '',
+    spriteId: null,
+    persona: undefined,
   })
 })

--- a/tests/renderer/SessionDrawer.test.tsx
+++ b/tests/renderer/SessionDrawer.test.tsx
@@ -5,8 +5,8 @@ import { SessionDrawer } from '../../src/renderer/components/SessionDrawer'
 import type { Session } from '../../src/renderer/types/ipc'
 
 const sessions: Session[] = [
-  { id: 'a', name: 'session-a', agentType: 'claude', cwd: '/tmp/a', envVars: {}, scrollbackPath: '' },
-  { id: 'b', name: 'session-b', agentType: 'shell',  cwd: '/tmp/b', envVars: {}, scrollbackPath: '' },
+  { id: 'a', name: 'session-a', agentType: 'claude', cwd: '/tmp/a', envVars: {}, scrollbackPath: '', spriteId: null },
+  { id: 'b', name: 'session-b', agentType: 'shell',  cwd: '/tmp/b', envVars: {}, scrollbackPath: '', spriteId: null },
 ]
 
 test('renders all session names', () => {

--- a/tests/renderer/SpritePanel.test.tsx
+++ b/tests/renderer/SpritePanel.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react'
+import { render, screen, act } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { SpritePanel } from '../../src/renderer/components/SpritePanel'
+import { useSpritesStore } from '../../src/renderer/store/sprites'
+
+jest.mock('@dicebear/core', () => ({
+  createAvatar: jest.fn(() => ({ toString: () => '<svg data-testid="mock-avatar"></svg>' })),
+}))
+jest.mock('@dicebear/collection', () => ({ bottts: {} }))
+
+beforeEach(() => {
+  localStorage.clear()
+  useSpritesStore.setState({ sprites: [] })
+  ;(window as any).overseer = {
+    onSpriteSpeech: jest.fn().mockReturnValue(() => {}),
+  }
+})
+
+test('renders empty state when spriteId is null', () => {
+  render(<SpritePanel sessionId="s1" spriteId={null} animationState="idle" visible={true} onOpenStudio={() => {}} />)
+  expect(screen.getByText('No Sprite assigned')).toBeInTheDocument()
+  expect(screen.getByText('Open Studio')).toBeInTheDocument()
+})
+
+test('renders nothing when visible is false', () => {
+  render(<SpritePanel sessionId="s1" spriteId={null} animationState="idle" visible={false} onOpenStudio={() => {}} />)
+  expect(screen.queryByText('No Sprite assigned')).not.toBeInTheDocument()
+})
+
+test('renders avatar when spriteId matches a sprite in store', () => {
+  const { createSprite } = useSpritesStore.getState()
+  const sprite = createSprite({ name: 'Salty', style: 'bottts', seed: 'sailor', persona: '' })
+  render(<SpritePanel sessionId="s1" spriteId={sprite.id} animationState="idle" visible={true} onOpenStudio={() => {}} />)
+  expect(screen.getByText(/Salty/)).toBeInTheDocument()
+})
+
+test('renders empty state when spriteId does not match any sprite', () => {
+  render(<SpritePanel sessionId="s1" spriteId="nonexistent-id" animationState="idle" visible={true} onOpenStudio={() => {}} />)
+  expect(screen.getByText('No Sprite assigned')).toBeInTheDocument()
+})
+
+test('subscribes to onSpriteSpeech with the session id', () => {
+  render(<SpritePanel sessionId="s1" spriteId={null} animationState="idle" visible={true} onOpenStudio={() => {}} />)
+  expect((window as any).overseer.onSpriteSpeech).toHaveBeenCalled()
+})
+
+test('displays speech text when onSpriteSpeech fires for matching session', async () => {
+  const { createSprite } = useSpritesStore.getState()
+  const sprite = createSprite({ name: 'Salty', style: 'bottts', seed: 'sailor', persona: '' })
+  let capturedCb: ((p: { sessionId: string; text: string }) => void) | null = null
+  ;(window as any).overseer.onSpriteSpeech = jest.fn().mockImplementation(cb => {
+    capturedCb = cb
+    return () => {}
+  })
+  render(<SpritePanel sessionId="s1" spriteId={sprite.id} animationState="idle" visible={true} onOpenStudio={() => {}} />)
+
+  await act(async () => {
+    capturedCb?.({ sessionId: 's1', text: 'hello sailor' })
+  })
+
+  expect(screen.getByText('hello sailor')).toBeInTheDocument()
+})
+
+test('does not display speech for a different session', async () => {
+  const { createSprite } = useSpritesStore.getState()
+  const sprite = createSprite({ name: 'Salty', style: 'bottts', seed: 'sailor', persona: '' })
+  let capturedCb: ((p: { sessionId: string; text: string }) => void) | null = null
+  ;(window as any).overseer.onSpriteSpeech = jest.fn().mockImplementation(cb => {
+    capturedCb = cb
+    return () => {}
+  })
+  render(<SpritePanel sessionId="s1" spriteId={sprite.id} animationState="idle" visible={true} onOpenStudio={() => {}} />)
+
+  await act(async () => {
+    capturedCb?.({ sessionId: 'OTHER', text: 'not for me' })
+  })
+
+  expect(screen.queryByText('not for me')).not.toBeInTheDocument()
+})

--- a/tests/renderer/SpriteStudio.test.tsx
+++ b/tests/renderer/SpriteStudio.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { SpriteStudio } from '../../src/renderer/components/SpriteStudio'
+import { useSpritesStore } from '../../src/renderer/store/sprites'
+
+jest.mock('@dicebear/core', () => ({
+  createAvatar: jest.fn(() => ({ toString: () => '<svg></svg>' })),
+}))
+jest.mock('@dicebear/collection', () => ({ bottts: {} }))
+
+beforeEach(() => {
+  localStorage.clear()
+  useSpritesStore.setState({ sprites: [] })
+  jest.useFakeTimers()
+})
+
+afterEach(() => {
+  jest.useRealTimers()
+})
+
+test('renders "New Sprite" heading when no editingId', () => {
+  render(<SpriteStudio onClose={() => {}} />)
+  expect(screen.getByText('New Sprite')).toBeInTheDocument()
+})
+
+test('renders "Edit Sprite" heading when editingId provided', () => {
+  const { createSprite } = useSpritesStore.getState()
+  const sprite = createSprite({ name: 'Salty', style: 'bottts', seed: 'sailor', persona: 'grumpy' })
+  render(<SpriteStudio onClose={() => {}} editingId={sprite.id} />)
+  expect(screen.getByText('Edit Sprite')).toBeInTheDocument()
+})
+
+test('calls onClose when Cancel is clicked', () => {
+  const onClose = jest.fn()
+  render(<SpriteStudio onClose={onClose} />)
+  fireEvent.click(screen.getByText('Cancel'))
+  expect(onClose).toHaveBeenCalled()
+})
+
+test('creates a new sprite and calls onClose on Save', () => {
+  const onClose = jest.fn()
+  render(<SpriteStudio onClose={onClose} />)
+  fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Salty' } })
+  fireEvent.change(screen.getByLabelText('Avatar Seed'), { target: { value: 'sailor123' } })
+  fireEvent.change(screen.getByLabelText('Persona'), { target: { value: 'grumpy old sailor' } })
+  fireEvent.click(screen.getByText('Save'))
+  expect(onClose).toHaveBeenCalled()
+  const sprites = useSpritesStore.getState().sprites
+  expect(sprites).toHaveLength(1)
+  expect(sprites[0].name).toBe('Salty')
+  expect(sprites[0].seed).toBe('sailor123')
+  expect(sprites[0].persona).toBe('grumpy old sailor')
+  expect(sprites[0].style).toBe('bottts')
+})
+
+test('updates an existing sprite on Save', () => {
+  const { createSprite } = useSpritesStore.getState()
+  const sprite = createSprite({ name: 'Salty', style: 'bottts', seed: 'sailor', persona: 'grumpy' })
+  const onClose = jest.fn()
+  render(<SpriteStudio onClose={onClose} editingId={sprite.id} />)
+  fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Salty McSaltface' } })
+  fireEvent.click(screen.getByText('Save'))
+  expect(onClose).toHaveBeenCalled()
+  expect(useSpritesStore.getState().sprites[0].name).toBe('Salty McSaltface')
+})
+
+test('Delete requires confirmation and auto-cancels after 2s', async () => {
+  const { createSprite } = useSpritesStore.getState()
+  const sprite = createSprite({ name: 'Salty', style: 'bottts', seed: 'sailor', persona: '' })
+  render(<SpriteStudio onClose={() => {}} editingId={sprite.id} />)
+
+  fireEvent.click(screen.getByText('Delete'))
+  expect(screen.getByText('Confirm Delete')).toBeInTheDocument()
+  expect(useSpritesStore.getState().sprites).toHaveLength(1)
+
+  await act(async () => { jest.advanceTimersByTime(2000) })
+
+  expect(screen.getByText('Delete')).toBeInTheDocument()
+  expect(screen.queryByText('Confirm Delete')).not.toBeInTheDocument()
+})
+
+test('Delete removes sprite when confirmed', () => {
+  const { createSprite } = useSpritesStore.getState()
+  const sprite = createSprite({ name: 'Salty', style: 'bottts', seed: 'sailor', persona: '' })
+  const onClose = jest.fn()
+  render(<SpriteStudio onClose={onClose} editingId={sprite.id} />)
+
+  fireEvent.click(screen.getByText('Delete'))
+  fireEvent.click(screen.getByText('Confirm Delete'))
+
+  expect(onClose).toHaveBeenCalled()
+  expect(useSpritesStore.getState().sprites).toHaveLength(0)
+})

--- a/tests/renderer/TabBar.test.tsx
+++ b/tests/renderer/TabBar.test.tsx
@@ -5,8 +5,8 @@ import { TabBar } from '../../src/renderer/components/TabBar'
 import type { Session } from '../../src/renderer/types/ipc'
 
 const sessions: Session[] = [
-  { id: 'a', name: 'claude-main', agentType: 'claude', cwd: '/tmp', envVars: {}, scrollbackPath: '' },
-  { id: 'b', name: 'gemini-test', agentType: 'gemini', cwd: '/tmp', envVars: {}, scrollbackPath: '' },
+  { id: 'a', name: 'claude-main', agentType: 'claude', cwd: '/tmp', envVars: {}, scrollbackPath: '', spriteId: null },
+  { id: 'b', name: 'gemini-test', agentType: 'gemini', cwd: '/tmp', envVars: {}, scrollbackPath: '', spriteId: null },
 ]
 
 test('renders a tab for each session', () => {

--- a/tests/renderer/sprites-store.test.tsx
+++ b/tests/renderer/sprites-store.test.tsx
@@ -1,0 +1,54 @@
+import { useSpritesStore } from '../../src/renderer/store/sprites'
+
+beforeEach(() => {
+  localStorage.clear()
+  useSpritesStore.setState({ sprites: [] })
+})
+
+test('createSprite adds a sprite with a generated id', () => {
+  const { createSprite } = useSpritesStore.getState()
+  const sprite = createSprite({ name: 'Salty', style: 'bottts', seed: 'sailor', persona: 'old sailor' })
+  expect(sprite.id).toBeTruthy()
+  expect(typeof sprite.id).toBe('string')
+  expect(useSpritesStore.getState().sprites).toHaveLength(1)
+  expect(useSpritesStore.getState().sprites[0].name).toBe('Salty')
+})
+
+test('createSprite gives each sprite a unique id', () => {
+  const { createSprite } = useSpritesStore.getState()
+  const a = createSprite({ name: 'A', style: 'bottts', seed: 'a', persona: '' })
+  const b = createSprite({ name: 'B', style: 'bottts', seed: 'b', persona: '' })
+  expect(a.id).not.toBe(b.id)
+})
+
+test('updateSprite patches only the named fields', () => {
+  const { createSprite, updateSprite } = useSpritesStore.getState()
+  const sprite = createSprite({ name: 'Salty', style: 'bottts', seed: 'sailor', persona: 'grumpy sailor' })
+  updateSprite(sprite.id, { name: 'Salty McSaltface' })
+  const updated = useSpritesStore.getState().sprites[0]
+  expect(updated.name).toBe('Salty McSaltface')
+  expect(updated.persona).toBe('grumpy sailor')
+})
+
+test('updateSprite ignores unknown ids', () => {
+  const { createSprite, updateSprite } = useSpritesStore.getState()
+  createSprite({ name: 'Salty', style: 'bottts', seed: 'sailor', persona: 'grumpy' })
+  updateSprite('does-not-exist', { name: 'X' })
+  expect(useSpritesStore.getState().sprites[0].name).toBe('Salty')
+})
+
+test('deleteSprite removes the sprite by id', () => {
+  const { createSprite, deleteSprite } = useSpritesStore.getState()
+  const sprite = createSprite({ name: 'Salty', style: 'bottts', seed: 'sailor', persona: '' })
+  deleteSprite(sprite.id)
+  expect(useSpritesStore.getState().sprites).toHaveLength(0)
+})
+
+test('deleteSprite leaves other sprites untouched', () => {
+  const { createSprite, deleteSprite } = useSpritesStore.getState()
+  const a = createSprite({ name: 'A', style: 'bottts', seed: 'a', persona: '' })
+  const b = createSprite({ name: 'B', style: 'bottts', seed: 'b', persona: '' })
+  deleteSprite(a.id)
+  expect(useSpritesStore.getState().sprites).toHaveLength(1)
+  expect(useSpritesStore.getState().sprites[0].id).toBe(b.id)
+})

--- a/tests/renderer/useCompanion.test.tsx
+++ b/tests/renderer/useCompanion.test.tsx
@@ -9,6 +9,7 @@ const mockSession: Session = {
   cwd: '/home/test',
   envVars: {},
   scrollbackPath: '',
+  spriteId: null,
 }
 
 beforeEach(() => {

--- a/tests/renderer/useKeyboardShortcuts.test.tsx
+++ b/tests/renderer/useKeyboardShortcuts.test.tsx
@@ -20,6 +20,8 @@ function makeHandlers(): ShortcutHandlers {
     onSplitSwap:            jest.fn(),
     onSplitSwapSecondary:   jest.fn(),
     onSplitToggleDirection: jest.fn(),
+    onToggleSpritePanel:   jest.fn(),
+    onOpenSpriteStudio:    jest.fn(),
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds an optional per-session character companion ("Sprite") rendered in the right sidebar using DiceBear SVG avatars
- Side-channel `<speak>` tag parser extracts speech from AI terminal output and displays auto-clearing speech bubbles without touching the xterm stream
- Sprite Studio modal for creating/editing/deleting sprites; persona is injected into claude sessions via system prompt at spawn time

## New Features
- **SpritePanel** — avatar + speech bubble in the right sidebar, 8-second auto-clear
- **SpriteStudio** — create/edit/delete modal with live preview (`Ctrl+Shift+P`)
- **Toggle sprite panel** keyboard shortcut (`Ctrl+Shift+S`)
- **Per-session sprite assignment** in New Session dialog
- **Persona injection** for claude agent type (written to PTY after 300ms)

## Test Plan
- [ ] Create a sprite in Sprite Studio (`Ctrl+Shift+P`)
- [ ] Open a new session and assign the sprite
- [ ] Verify avatar appears in the right sidebar
- [ ] For claude sessions: verify persona prompt is injected
- [ ] Trigger a `<speak>hello</speak>` tag in the terminal and verify speech bubble appears and clears after 8 seconds
- [ ] Toggle sprite panel with `Ctrl+Shift+S`
- [ ] Verify sessions without a sprite show empty state in panel
- [ ] Run `npm test` — 157 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)